### PR TITLE
Allow for efficient SSA (Gillespie) simulations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.2.0"
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
+JumpProcesses = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 SBML = "e5567a89-2604-4b09-9718-f5f78e97c3bb"
+Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]

--- a/src/Callbacks.jl
+++ b/src/Callbacks.jl
@@ -202,6 +202,9 @@ function create_callback_SBML_event(event_name::String,
         affect_function *= "\t" * affect_function1 * " = " * affect_function2 * '\n'
         affect_function_body *= "\t" * affect_function1 * " = " * affect_function2 * '\n' # For t0 events
     end
+    # For Jump simulations to get correct SSA simulations
+    affect_function *= "\tif integrator.sol.prob isa DiscreteProblem\n"
+    affect_function *= "\t\treset_aggregated_jumps!(integrator)\n\tend\n"
     affect_function *= "end"
     for i in eachindex(p_ode_problem_names)
         affect_function = replace_variable(affect_function, p_ode_problem_names[i], "integrator.p["*string(i)*"]")

--- a/src/SBMLImporter.jl
+++ b/src/SBMLImporter.jl
@@ -8,6 +8,8 @@ using RuntimeGeneratedFunctions
 using SBML
 using SpecialFunctions
 using Catalyst
+using Setfield
+using JumpProcesses
 
 RuntimeGeneratedFunctions.init(@__MODULE__)
 

--- a/src/Structs.jl
+++ b/src/Structs.jl
@@ -51,6 +51,7 @@ mutable struct ReactionSBML
     const products_stoichiometry::Vector{String}
     const reactants::Vector{String}
     const reactants_stoichiometry::Vector{String}
+    const stoichiometry_mass_action::Bool
 end
 
 

--- a/test/Stochastic_tests.jl
+++ b/test/Stochastic_tests.jl
@@ -1,0 +1,154 @@
+using SBMLImporter
+using CSV
+using DataFrames
+using OrdinaryDiffEq
+using ModelingToolkit
+using SBML
+using Test
+using Downloads
+using Catalyst
+using JumpProcesses
+
+
+function get_sbml_urls(base_url::String)
+    levels = ["2", "3"]
+    sublevels = ["1", "2", "3", "4", "5"]
+    sbml_urls = Vector{String}(undef, 0)
+
+    for level in levels
+        for sublevel in sublevels
+            sbml_url = base_url * "-sbml-l" * level * "v" * sublevel * ".xml"
+            try
+                sbml = String(take!(Downloads.download(sbml_url, IOBuffer())))
+                push!(sbml_urls, sbml_url)
+            catch
+            end
+        end
+    end
+    return sbml_urls
+end
+
+
+function get_model_str(test_case)
+    base_url = "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/stochastic/$test_case/$test_case"
+    sbml_urls = get_sbml_urls(base_url)
+    sbml_url = sbml_urls[end]
+    sbml_string = String(take!(Downloads.download(sbml_url, IOBuffer())))
+    model_SBML = SBMLImporter.build_SBML_model(sbml_string, model_as_string=true)
+    reaction_system = SBMLImporter.reactionsystem_from_SBML(model_SBML, "", false)
+    return reaction_system, model_SBML
+end
+
+
+function read_settings(settings_url::String)
+
+    settings = String(take!(Downloads.download(settings_url, IOBuffer())))
+    settings_lines = split(settings, '\n')
+    species_test = Symbol.(replace.(split(split(settings_lines[4], ":")[2], ','), " " => "", ))
+
+    mean_range = parse.(Float64, split(replace.(split(settings_lines[10], ":")[2], r"\(|\)| " => ""), ","))
+    sd_range = parse.(Float64, split(replace.(split(settings_lines[11], ":")[2], r"\(|\)| " => ""), ","))
+
+    return species_test, mean_range, sd_range
+end
+
+
+function test_stochastic_testcase(test_case::String; nsolve::Integer=20000)
+
+    base_url = "https://raw.githubusercontent.com/sbmlteam/sbml-test-suite/master/cases/stochastic/$test_case/$test_case"
+
+    species_test, mean_range, sd_range = read_settings(base_url * "-settings.txt")
+
+    _results_url = base_url * "-results.csv"
+    _results = String(take!(Downloads.download(_results_url, IOBuffer())))
+    results = CSV.read(IOBuffer(_results), DataFrame)
+    t_save = "Time" in names(results) ? Float64.(results[!, :Time]) : Float64.(results[!, :time])
+    t_save = Vector{Float64}(t_save)
+    tmax = maximum(t_save)
+
+    sbml_urls = get_sbml_urls(base_url)
+    sbml_url = sbml_urls[end]
+
+    # To reduce runtime for the most demanding test-case
+    if test_case == "00005"
+        sbml_urls = [sbml_urls[end]]
+    end
+
+    for sbml_url in sbml_urls
+
+        sbml_string = String(take!(Downloads.download(sbml_url, IOBuffer())))
+        # c = n / V => n = c * V
+
+        model_SBML = SBMLImporter.build_SBML_model(sbml_string, model_as_string=true)
+        # If stoichiometryMath occurs we need to convert the SBML file to a level 3 file
+        # to properly handle it
+        if occursin("stoichiometryMath", sbml_string) == false
+            libsbml_model = readSBMLFromString(sbml_string)
+        else
+            libsbml_model = readSBMLFromString(sbml_string, doc -> begin
+                                set_level_and_version(3, 2)(doc)
+                                convert_promotelocals_expandfuns(doc)
+                                end)
+        end
+
+        #SBMLImporter.SBML_to_ODESystem(sbml_string, ret_all=true, model_as_string=true, write_to_file=true)
+        reaction_system, specie_map, parameter_map, cb, get_tstops, ifelse_t0 = SBMLImporter.SBML_to_ReactionSystem(sbml_string, ret_all=true, model_as_string=true)
+        tspan = (0.0, tmax)
+        dprob = DiscreteProblem(reaction_system, specie_map, tspan, parameter_map)
+        jprob = JumpProblem(reaction_system, dprob, Direct(); save_positions=(false, false))
+        for _f! in ifelse_t0
+            _f!(jprob.u0, jprob.p)
+        end
+        tstops = get_tstops(dprob.u0, dprob.p)
+        eprob = EnsembleProblem(jprob)
+        if test_case != "00033"
+            sol = solve(eprob, SSAStepper(), EnsembleSerial(), trajectories = nsolve, saveat=t_save, tstops=tstops, callback=cb)
+        else
+            sol = solve(eprob, FunctionMap(), EnsembleSerial(), trajectories = nsolve, saveat=t_save, tstops=tstops, callback=cb)
+        end
+        model_parameters = parameters(reaction_system)
+
+        for to_check in species_test
+            to_check_no_whitespace = replace(string(to_check), " " => "")
+            i_specie = findfirst(x -> x == to_check_no_whitespace, replace.(string.(states(jprob.prob.f.sys)), "(t)" => ""))
+            sim_mean, sim_var = SciMLBase.EnsembleAnalysis.timepoint_meanvar(sol, t_save)
+            sim_mean = sim_mean[i_specie, :]
+            sim_sd = sqrt.(sim_var[i_specie, :])
+
+            if to_check_no_whitespace * "-mean" ∈ names(results)
+                reference_sol = results[!, to_check_no_whitespace * "-mean"]
+                @test all(reference_sol .+ mean_range[1] .< sim_mean .< reference_sol .+ mean_range[2])
+            end
+
+            if to_check_no_whitespace * "-sd" ∈ names(results)
+                reference_sol = results[!, to_check_no_whitespace * "-sd"]
+                @test all(reference_sol .+ sd_range[1] .< sim_sd .< reference_sol .+ sd_range[2])
+            end
+        end
+    end
+end
+
+
+@testset "Stochastic tests" begin
+    for i in 1:39
+
+        # 19 has assignment rule 
+        # 33 has continious callback
+        if i ∈ [19, 33]
+            continue
+        end
+
+        @info "Test case $i"
+        test_case = repeat("0", 5 - length(string(i))) *  string(i)
+        
+        # i = 5 nast test case were many simulations must be run to get a 
+        # good mean estimate (as amounts are large)
+        if i == 5
+            test_stochastic_testcase(test_case; nsolve=70000)
+        else
+            test_stochastic_testcase(test_case)
+        end
+        
+    end
+end
+

--- a/test/Testsuite_catalyst.jl
+++ b/test/Testsuite_catalyst.jl
@@ -94,8 +94,6 @@ function check_test_case(test_case, solver)
                                 end)
         end
 
-        #SBMLImporter.SBML_to_ODESystem(sbml_string, ret_all=true, model_as_string=true, write_to_file=true)
-
         reaction_system, specie_map, parameter_map, cb, get_tstops, ifelse_t0 = SBMLImporter.SBML_to_ReactionSystem(sbml_string, ret_all=true, model_as_string=true)
         if isempty(model_SBML.algebraic_rules)
             ode_system = structural_simplify(convert(ODESystem, reaction_system))
@@ -165,10 +163,13 @@ function get_model_str(test_case)
     sbml_url = sbml_urls[end]
     sbml_string = String(take!(Downloads.download(sbml_url, IOBuffer())))
     model_SBML = SBMLImporter.build_SBML_model(sbml_string, model_as_string=true)
-    reaction_system = SBMLImporter.reactionsystem_from_SBML(model_SBML)
+    reaction_system = SBMLImporter.reactionsystem_from_SBML(model_SBML, "", false)
     return reaction_system, model_SBML
 end
 
+
+rn_str, model_SBML = get_model_str("01645")
+#check_test_case("01645", Rodas4P())
 
 # To run this you might have to add Catalyst into the SBMLImporter.jl file 
 solver = Rodas4P()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using SafeTestsets
 
-@safetestset "SBML test-suite" begin
+@safetestset "SBML semantic test-suite" begin
     include("Testsuite_catalyst.jl")
+end
+
+@safetestset "SBML stochastic test-suite" begin
+    include("Stochastic_tests.jl")
 end


### PR DESCRIPTION
For models where Gillespie is feasible (species are in amounts, mass-action kinetics, and only_substance_units=true) models are now imported into Catalyst as mass-action models with only_use_rate=false to allow for efficient SSA simulations. Tested against the stochastic part of the SBML test-suite, and locally does not cause any problems with PEtab.jl.

See #18 