### PR TITLE
Reduce runtime for larger models

### DIFF
--- a/src/Build_model.jl
+++ b/src/Build_model.jl
@@ -9,7 +9,8 @@ Rewriting ifelse to Boolean callbacks is strongly recomended if possible.
 
 For testing path_SBML can be the model as a string if model_as_string=true
 """
-function build_SBML_model(path_SBML::String; ifelse_to_callback::Bool=true, model_as_string=true)::ModelSBML
+function build_SBML_model(path_SBML::String; ifelse_to_callback::Bool=true, model_as_string=true, 
+                         inline_assignment_rules::Bool=true)::ModelSBML
 
     if model_as_string == false
         f = open(path_SBML, "r")
@@ -45,12 +46,13 @@ function build_SBML_model(path_SBML::String; ifelse_to_callback::Bool=true, mode
                                  end)
     end
 
-    return _build_SBML_model(libsbml_model, ifelse_to_callback)
+    return _build_SBML_model(libsbml_model, ifelse_to_callback, inline_assignment_rules)
 end
 
 
 
-function _build_SBML_model(libsbml_model::SBML.Model, ifelse_to_callback::Bool)::ModelSBML
+function _build_SBML_model(libsbml_model::SBML.Model, ifelse_to_callback::Bool, 
+                           inline_assignment_rules::Bool)::ModelSBML
 
     conversion_factor = isnothing(libsbml_model.conversion_factor) ? "" : libsbml_model.conversion_factor
     
@@ -130,6 +132,12 @@ function _build_SBML_model(libsbml_model::SBML.Model, ifelse_to_callback::Bool):
     # Up to this point for models parameter the SBML rem or div function might appear in the model dynamics,
     # these are non differentialble, discrete and not allowed
     has_rem_or_div(model_SBML)
+
+    # Inlining assignment rule variables makes the model in a sense less readable, however, if not done for 
+    # larger models Catalyst might crash due to a stack-overflow error, and model load times become longer 
+    if inline_assignment_rules == true
+       inline_assignment_rules!(model_SBML) 
+    end
 
     return model_SBML
 end

--- a/src/Callbacks.jl
+++ b/src/Callbacks.jl
@@ -2,7 +2,8 @@
 # using ifelse (for example better integration stability, faster runtimes etc...)
 function create_callbacks_SBML(system,
                                model_SBML::ModelSBML,
-                               model_name::String)
+                               model_name::String;
+                               convert_stpan::Bool=false)
 
     p_ode_problem_names::Vector{String} = string.(parameters(system))
     model_specie_names::Vector{String} = replace.(string.(states(system)), "(t)" => "")

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -57,7 +57,7 @@ function process_SBML_str_formula(formula::T, model_SBML::ModelSBML, libsbml_mod
         if id ∉ model_SBML.specie_reference_ids
             continue
         end
-        if id ∉ keys(model_SBML.species) && rate_rule == false
+        if !haskey(model_SBML.species, id) && rate_rule == false
             continue
         end
         if isnothing(id)
@@ -85,16 +85,15 @@ function process_SBML_str_formula(formula::T, model_SBML::ModelSBML, libsbml_mod
                 if isnothing(specie_reference.id)
                     continue
                 end
-                if specie_reference.id ∈ keys(libsbml_model.species)
+                if haskey(libsbml_model.species, specie_reference.id)
                     continue
                 end
-                if specie_reference.id ∈ keys(libsbml_model.initial_assignments)
+                if haskey(libsbml_model.initial_assignments, specie_reference.id) 
                     continue
                 end
                 if specie_reference.id ∈ [rule isa SBML.AlgebraicRule ? "" : rule.variable for rule in libsbml_model.rules]
                     continue
                 end
-                println("Ends up here")
                 _formula = replace_variable(_formula, specie_reference.id, string(specie_reference.stoichiometry))
             end
         end
@@ -177,12 +176,12 @@ function replace_rateOf(_formula::T, model_SBML::ModelSBML)::String where T<:Uni
     for (i, arg) in pairs(args)
 
         # A constant parameter does not have a rate
-        if arg ∈ keys(model_SBML.parameters) && model_SBML.parameters[arg].constant == true
+        if haskey(model_SBML.parameters, arg) && model_SBML.parameters[arg].constant == true
             replace_with[i] = "0.0"
             continue
         end
         # A parameter via a rate-rule has a rate
-        if arg ∈ keys(model_SBML.parameters) && model_SBML.parameters[arg].rate_rule == true
+        if haskey(model_SBML.parameters, arg) && model_SBML.parameters[arg].rate_rule == true
             replace_with[i] = model_SBML.parameters[arg].formula
             continue
         end
@@ -194,7 +193,7 @@ function replace_rateOf(_formula::T, model_SBML::ModelSBML)::String where T<:Uni
         end
 
         # If specie is via a rate-rule we do not scale the state in the expression
-        if arg ∈ keys(model_SBML.species) && model_SBML.species[arg].rate_rule == true
+        if haskey(model_SBML.species, arg) && model_SBML.species[arg].rate_rule == true
             replace_with[i] = model_SBML.species[arg].formula
             continue
         end
@@ -320,151 +319,6 @@ function is_number(x::SubString{String})::Bool
 end
 
 
-# For when exporting to ODESystem or ReactionSystem 
-function get_specie_map(model_SBML::ModelSBML; reaction_system::Bool=false)::Tuple{String, String, String}
-
-    if reaction_system == false
-        _species_write = "\tModelingToolkit.@variables t "
-    else
-        _species_write = "\tModelingToolkit.@variables t\n\tsps = Catalyst.@species "
-    end
-    _species_write_array = "\tspecies = ["
-    _specie_map_write = "\tspecie_map = [\n"
-    
-    # Identify which variables/parameters are dynamic 
-    for specie_id in keys(model_SBML.species)
-        _species_write *= specie_id * "(t) "
-        _species_write_array *= specie_id * ", "
-    end
-    for (parameter_id, parameter) in model_SBML.parameters
-        if parameter.constant == true
-            continue
-        end
-        # Happens when the assignment rule has been inlined, and thus should not be included 
-        # as a model variable with an initial value
-        if (parameter.assignment_rule == true && 
-            parameter_id ∉ model_SBML.algebraic_rule_variables && 
-            parameter.rate_rule == false)
-            continue
-        end
-        _species_write *= parameter_id * "(t) "
-        _species_write_array *= parameter_id * ", "
-    end
-    for (compartment_id, compartment) in model_SBML.compartments
-        if compartment.constant == true
-            continue
-        end
-        _species_write *= compartment_id * "(t) "
-        _species_write_array *= compartment_id * ", "
-    end
-    _species_write_array = _species_write_array[1:end-2] * "]" # Ensure correct valid syntax
-
-    # Map for initial values on time-dependent parameters 
-    for (specie_id, specie) in model_SBML.species
-        u0eq = specie.initial_value
-        _specie_map_write *= "\t" * specie_id * " =>" * u0eq * ",\n"
-    end
-    # Parameters
-    for (parameter_id, parameter) in model_SBML.parameters
-        if !(parameter.rate_rule == true || parameter.assignment_rule == true)
-            continue
-        end
-        # See comment above
-        if (parameter.assignment_rule == true && 
-            parameter_id ∉ model_SBML.algebraic_rule_variables && 
-            parameter.rate_rule == false)
-            continue
-        end
-        u0eq = parameter.initial_value
-        _specie_map_write *= "\t" * parameter_id * " => " * u0eq * ",\n"
-    end
-    # Compartments
-    for (compartment_id, compartment) in model_SBML.compartments
-        if compartment.rate_rule != true
-            continue
-        end
-        u0eq = compartment.initial_value
-        _specie_map_write *= "\t" * compartment_id * " => " * u0eq * ",\n"
-    end
-    _specie_map_write *= "\t]"
-
-
-    return _species_write, _species_write_array, _specie_map_write
-end
-
-
-# For when exporting to ODESystem or ReactionSystem 
-function get_parameter_map(model_SBML::ModelSBML; reaction_system::Bool=false)::Tuple{String, String, String}
-
-    if reaction_system == false
-        _parameters_write = "\tModelingToolkit.@parameters "
-    else
-        _parameters_write = "\tps = Catalyst.@parameters "
-    end
-    _parameters_write_array = "\tparameters = ["
-    _parameter_map_write = "\tparameter_map = [\n"
-    
-    for (parameter_id, parameter) in model_SBML.parameters
-        if parameter.constant == false
-            continue
-        end
-        # For ReactionSystem we carefully need to separate species and variables
-        if reaction_system == true && parameter.assignment_rule == true
-            continue
-        end
-        # In case assignment rule variables have been inlined they should not be 
-        # a part of the parameter-map 
-        if parameter.assignment_rule == true && parameter_id ∉ model_SBML.assignment_rule_variables
-            continue
-        end
-        _parameters_write *= parameter_id * " "
-        _parameters_write_array *= parameter_id * ", "
-    end
-    for (compartment_id, compartment) in model_SBML.compartments
-        if compartment.constant == false
-            continue
-        end
-        # For ReactionSystem we carefully need to separate species and variables
-        if reaction_system == true && compartment.assignment_rule == true
-            continue
-        end
-        _parameters_write *= compartment_id * " "
-        _parameters_write_array *= compartment_id * ", "
-    end
-    # Special case where we do not have any parameters
-    if length(_parameters_write) == 29 && _parameters_write[1:14] != "\tps = Catalyst"
-        _parameters_write = ""
-        _parameters_write_array *= "]"
-    else
-        _parameters_write_array = _parameters_write_array[1:end-2] * "]"
-    end
-
-    # Map setting initial values for parameters 
-    for (parameter_id, parameter) in model_SBML.parameters
-        if parameter.constant == false
-            continue
-        end
-        # In case assignment rule variables have been inlined they should not be 
-        # a part of the parameter-map 
-        if parameter.assignment_rule == true && parameter_id ∉ model_SBML.assignment_rule_variables
-            continue
-        end
-        peq = parameter.formula
-        _parameter_map_write *= "\t" * parameter_id * " =>" * peq * ",\n"
-    end
-    for (compartment_id, compartment) in model_SBML.compartments
-        if compartment.constant == false
-            continue
-        end
-        ceq = compartment.formula
-        _parameter_map_write *= "\t" * compartment_id * " =>" * ceq * ",\n"
-    end
-    _parameter_map_write *= "\t]"
-
-    return _parameters_write, _parameters_write_array, _parameter_map_write
-end
-
-
 function get_specie_reference_ids(libsbml_model::SBML.Model)::Vector{String}
 
     specie_reference_ids = String[]
@@ -483,4 +337,18 @@ function get_specie_reference_ids(libsbml_model::SBML.Model)::Vector{String}
         end
     end
     return specie_reference_ids
+end
+
+
+function get_rule_variables!(model_SBML::ModelSBML)::Nothing
+
+    _rule_variables = unique(vcat(model_SBML.rate_rule_variables, model_SBML.assignment_rule_variables,
+                                  model_SBML.algebraic_rule_variables))
+    filter!(x -> x ∉ keys(model_SBML.generated_ids), _rule_variables)
+
+    for var in _rule_variables
+        push!(model_SBML.rule_variables, var)
+    end
+
+    return nothing
 end

--- a/src/Events.jl
+++ b/src/Events.jl
@@ -4,7 +4,7 @@ function parse_SBML_events!(model_SBML::ModelSBML, libsbml_model::SBML.Model)::N
     for (event_name, event) in libsbml_model.events
 
         # Parse the event trigger into proper Julia syntax
-        formula_trigger = parse_SBML_math(event.trigger.math)
+        formula_trigger, _ = parse_SBML_math(event.trigger.math)
         formula_trigger = SBML_function_to_math(formula_trigger, model_SBML.functions)
         if isempty(formula_trigger)
             continue
@@ -18,7 +18,7 @@ function parse_SBML_events!(model_SBML::ModelSBML, libsbml_model::SBML.Model)::N
         for (i, event_assignment) in pairs(event.event_assignments)
 
             # Check if event should be ignored as no math child was provided 
-            if isempty(parse_SBML_math(event_assignment.math))
+            if isempty(parse_SBML_math(event_assignment.math)[1])
                 not_skip_assignments[i] = false
                 continue
             end
@@ -26,7 +26,7 @@ function parse_SBML_events!(model_SBML::ModelSBML, libsbml_model::SBML.Model)::N
             event_assignments[i] = event_assignment.variable
 
             # Parse the event formula into the correct Julia syntax 
-            event_formulas[i] = parse_SBML_math(event_assignment.math)
+            event_formulas[i] = parse_SBML_math(event_assignment.math)[1]
             event_formulas[i] = replace_variable(event_formulas[i], "t", "integrator.t")
             event_formulas[i] = replace_reactionid_formula(event_formulas[i], libsbml_model)
             event_formulas[i] = process_SBML_str_formula(event_formulas[i], model_SBML, libsbml_model; check_scaling=false)

--- a/src/Events.jl
+++ b/src/Events.jl
@@ -33,7 +33,7 @@ function parse_SBML_events!(model_SBML::ModelSBML, libsbml_model::SBML.Model)::N
             
             # Formulas are given in concentration, but species can also be given in amounts. Thus, we must 
             # adjust for compartment for the latter
-            if event_assignments[i] ∈ keys(model_SBML.species)
+            if haskey(model_SBML.species, event_assignments[i])
                 if model_SBML.species[event_assignments[i]].unit == :Concentration
                     continue
                 end
@@ -44,10 +44,11 @@ function parse_SBML_events!(model_SBML::ModelSBML, libsbml_model::SBML.Model)::N
                 event_formulas[i] = compartment_formula *  " * (" * event_formulas[i] * ')'
                 continue
             end
-            if event_assignments[i] ∈ keys(libsbml_model.parameters)  
+            if haskey(model_SBML.parameters, event_assignments[i])
                 continue
             end
-            if event_assignments[i] ∈ keys(libsbml_model.compartments) && model_SBML.compartments[event_assignments[i]].constant == false
+            if (haskey(model_SBML.compartments, event_assignments[i]) && 
+                model_SBML.compartments[event_assignments[i]].constant == false)      
                 continue
             end
 
@@ -104,7 +105,7 @@ function adjust_event_compartment_change!!!(event_formulas::Vector{String},
 
         # Only potentiallt adjust species if a compartment is assigned to in the 
         # event
-        if assign_to ∉ keys(model_SBML.compartments)
+        if !haskey(model_SBML.compartments, assign_to)
             continue
         end
 

--- a/src/Functions.jl
+++ b/src/Functions.jl
@@ -49,7 +49,7 @@ function SBML_function_to_math(formula::T, model_functions::Dict)::T where T<:Ab
     match_parentheses_regex = Regex("\\((?:[^)(]*(?R)?)*+\\)")
 
     # In case no functions occur in the formula
-    if !any(occursin.(collect(keys(model_functions)), formula))
+    if !any(occursin.(keys(model_functions), formula))
         return formula
     end
 
@@ -109,8 +109,7 @@ function SBML_function_to_math(formula::T, model_functions::Dict)::T where T<:Ab
     end
 
     # In case of nested function recursively processes nested functions
-    _model_functions = collect(keys(model_functions))
-    if any(occursin.(_model_functions, _formula))
+    if any(occursin.(keys(model_functions), _formula))
         _formula = SBML_function_to_math(_formula, model_functions)
     end
 

--- a/src/Functions.jl
+++ b/src/Functions.jl
@@ -7,7 +7,7 @@ function parse_SBML_functions!(model_SBML::ModelSBML, libsbml_model::SBML.Model)
         end
         
         args = get_SBML_function_args(SBML_function)
-        function_formula = parse_SBML_math(SBML_function.body.body, true)
+        function_formula, _ = parse_SBML_math(SBML_function.body.body, true)
         model_SBML.functions[function_name] = [args, function_formula]
     end
     return nothing

--- a/src/Initial_assignments.jl
+++ b/src/Initial_assignments.jl
@@ -4,7 +4,7 @@ function parse_SBML_initial_assignments!(model_SBML::ModelSBML, libsbml_model::S
     for (assign_id, initial_assignment) in libsbml_model.initial_assignments
 
         # Parse the assignment formula to Julia syntax
-        formula = parse_SBML_math(initial_assignment)
+        formula, _ = parse_SBML_math(initial_assignment)
         if occursin("piecewise", formula) && assign_id ∈ keys(model_SBML.species)
             throw(SBMLSupport("Piecewise expressions in initial assignments for species are not supported"))
         end

--- a/src/Initial_assignments.jl
+++ b/src/Initial_assignments.jl
@@ -5,7 +5,7 @@ function parse_SBML_initial_assignments!(model_SBML::ModelSBML, libsbml_model::S
 
         # Parse the assignment formula to Julia syntax
         formula, _ = parse_SBML_math(initial_assignment)
-        if occursin("piecewise", formula) && assign_id ∈ keys(model_SBML.species)
+        if occursin("piecewise", formula) && haskey(model_SBML.species, assign_id)
             throw(SBMLSupport("Piecewise expressions in initial assignments for species are not supported"))
         end
         formula = replace_reactionid_formula(formula, libsbml_model)
@@ -16,12 +16,13 @@ function parse_SBML_initial_assignments!(model_SBML::ModelSBML, libsbml_model::S
             throw(SBMLSupport("and, or not supported in initial assignments"))
         end
 
-        if assign_id ∈ keys(model_SBML.species)
+        if haskey(model_SBML.species, assign_id)
             model_SBML.species[assign_id].initial_value = formula
             push!(assigned_states, assign_id)
 
-        elseif assign_id ∈ keys(model_SBML.parameters)
-            if assign_id ∈ keys(libsbml_model.initial_assignments) && assign_id ∈ model_SBML.rate_rule_variables
+        elseif haskey(model_SBML.parameters, assign_id)
+
+            if haskey(libsbml_model.initial_assignments, assign_id) && assign_id ∈ model_SBML.rate_rule_variables
                 model_SBML.parameters[assign_id].initial_value = formula
             else
                 # Here the parameter should be treated as given by an assignment rule, as it likelly is non-constant 
@@ -32,8 +33,8 @@ function parse_SBML_initial_assignments!(model_SBML::ModelSBML, libsbml_model::S
                 model_SBML.parameters[assign_id].assignment_rule = true
             end
 
-        elseif assign_id ∈ keys(model_SBML.compartments)
-            if assign_id ∈ keys(libsbml_model.initial_assignments) && assign_id ∈ model_SBML.rate_rule_variables
+        elseif haskey(model_SBML.compartments, assign_id)
+            if haskey(libsbml_model.initial_assignments, assign_id) && assign_id ∈ model_SBML.rate_rule_variables
                 model_SBML.compartments[assign_id].initial_value = formula
             else
                 # Here the compartment should be treated as given by an assignment rule, as it likelly is non-constant 
@@ -63,7 +64,7 @@ function parse_SBML_initial_assignments!(model_SBML::ModelSBML, libsbml_model::S
     # Initial assignment formula is given in conc, but if the state it acts on is given in amount
     # we need to adjust by multiplaying with compartment.
     for assign_id in assigned_states
-        if assign_id ∉ keys(model_SBML.species)
+        if !haskey(model_SBML.species, assign_id)
             continue
         end
         if model_SBML.species[assign_id].unit == :Concentration

--- a/src/Piecewise.jl
+++ b/src/Piecewise.jl
@@ -18,7 +18,7 @@ function piecewise_to_ifelse(rule_formula::String, model_SBML::ModelSBML, libsbm
     for (i, piecewise_eq) in pairs(piecewise_eqs)
 
         # Do not re-processes piecewise if already has been done
-        if piecewise_eq ∈ keys(model_SBML.piecewise_expressions)
+        if haskey(model_SBML.piecewise_expressions, piecewise_eq)
             ifelse_eqs[i] = model_SBML.piecewise_expressions[piecewise_eq]
             continue
         end
@@ -311,7 +311,7 @@ function _time_dependent_ifelse_to_bool(formula::String, model_SBML::ModelSBML, 
     for i in eachindex(indices_ifelse)
 
         ifelse_eq = formula[indices_ifelse[i]]
-        if ifelse_eq ∈ keys(model_SBML.ifelse_bool_expressions)
+        if haskey(model_SBML.ifelse_bool_expressions, ifelse_eq)
             formula_ret = replace(formula_ret, ifelse_eq => model_SBML.ifelse_bool_expressions[ifelse_eq])
         end
 
@@ -376,7 +376,7 @@ function _time_dependent_ifelse_to_bool(formula::String, model_SBML::ModelSBML, 
         local j = 1
         while true
             parameter_name = "__parameter_ifelse" * string(j)
-            if parameter_name ∉ keys(model_SBML.ifelse_parameters)
+            if !haskey(model_SBML.ifelse_parameters, parameter_name)
                 break
             end
             j += 1

--- a/src/Reactions.jl
+++ b/src/Reactions.jl
@@ -1,24 +1,22 @@
 function parse_SBML_reactions!(model_SBML::ModelSBML, libsbml_model::SBML.Model)::Nothing
 
     for (id, reaction) in libsbml_model.reactions
-        # Process kinetic math into Julia syntax 
+        # Process kinetic math into Julia syntax
         _formula, math_idents = parse_SBML_math(reaction.kinetic_math)
 
-        # Check if reactionId or assignment-rule variable appear in the kinetic math, 
-        # if they do they are a part of the math_idents 
+        # Check if reactionId or assignment-rule variable appear in the kinetic math,
+        # if they do they are a part of the math_idents, and need to be replaced
+        # in later processing steps
         has_assignment_rule_variable::Bool = false
         has_reaction_id::Bool = false
         for math_ident in math_idents
-            if haskey(model_SBML.reactions, math_ident)
+            if haskey(libsbml_model.reactions, math_ident)
                 has_reaction_id = true
             end
             if math_ident ∈ model_SBML.assignment_rule_variables
                 has_assignment_rule_variable = true
             end
         end
-
-        # Check if mass-action stocihim
-        stoichiometry_mass_action::Bool = true       
 
         # Add values for potential kinetic parameters (where-statements)
         for (parameter_id, parameter) in reaction.kinetic_parameters
@@ -36,23 +34,24 @@ function parse_SBML_reactions!(model_SBML::ModelSBML, libsbml_model::SBML.Model)
         reactants_stoichiometry = similar(reactants)
         products = Vector{String}(undef, length(reaction.products))
         products_stoichiometry = similar(products)
-        
+
+        stoichiometry_mass_action::Bool = true
         for (i, reactant) in pairs(reaction.reactants)
             push!(model_SBML.species_in_reactions, reactant.species)
             if model_SBML.species[reactant.species].boundary_condition == true
                 reactants_stoichiometry[i] = "nothing"
                 reactants[i] = "nothing"
-                continue                
+                continue
             end
             stoichiometry, _stoichiometry_mass_action = parse_stoichiometry(reactant, model_SBML)
             reactants[i] = reactant.species
             stoichiometry_mass_action = stoichiometry_mass_action == true && _stoichiometry_mass_action == false ? false : stoichiometry_mass_action
             compartment_scaling = get_compartment_scaling(reactant.species, formula, model_SBML)
             model_SBML.species[reactant.species].formula *= " - " * stoichiometry * compartment_scaling * "(" * formula * ")"
-    
-            # In case a specie is given in unit concentration we must scale the stoichiometry, this is bad for simulations 
-            # with Gillespie, however, concentrations and Gillespie do not match anyhow
-            reactants_stoichiometry[i] = stoichiometry * get_compartment_scaling(reactant.species, formula, model_SBML; stoichiometry=true)
+
+            # In case a specie is given in unit concentration we must scale the stoichiometry
+            reactants_stoichiometry[i] = stoichiometry * get_compartment_scaling(reactant.species, formula, model_SBML; 
+                                                                                 stoichiometry=true)
         end
 
         for (i, product) in pairs(reaction.products)
@@ -60,7 +59,7 @@ function parse_SBML_reactions!(model_SBML::ModelSBML, libsbml_model::SBML.Model)
             if model_SBML.species[product.species].boundary_condition == true
                 products_stoichiometry[i] = "nothing"
                 products[i] = "nothing"
-                continue                
+                continue
             end
             stoichiometry, _stoichiometry_mass_action = parse_stoichiometry(product, model_SBML)
             stoichiometry_mass_action = stoichiometry_mass_action == true && _stoichiometry_mass_action == false ? false : stoichiometry_mass_action
@@ -72,19 +71,19 @@ function parse_SBML_reactions!(model_SBML::ModelSBML, libsbml_model::SBML.Model)
             products_stoichiometry[i] = stoichiometry * get_compartment_scaling(product.species, formula, model_SBML; stoichiometry=true)
         end
 
-        model_SBML.reactions[id] = ReactionSBML(id, formula, products, products_stoichiometry, reactants, 
-                                                reactants_stoichiometry, stoichiometry_mass_action, 
+        model_SBML.reactions[id] = ReactionSBML(id, formula, products, products_stoichiometry, reactants,
+                                                reactants_stoichiometry, stoichiometry_mass_action,
                                                 has_assignment_rule_variable, has_reaction_id)
     end
 
     # Species given via assignment rules, or initial assignments which only affect stoichiometry
-    # are species that should not be included down the line in the model, hence they are 
-    # here removed from the model 
+    # are species that should not be included down the line in the model, hence they are
+    # here removed from the model
     remove_stoichiometry_math_from_species!(model_SBML, libsbml_model)
 end
 
 
-function get_compartment_scaling(specie::String, formula::String, model_SBML::ModelSBML; 
+function get_compartment_scaling(specie::String, formula::String, model_SBML::ModelSBML;
                                  stoichiometry::Bool=false)::String
 
     # The case of the specie likelly being given via an algebraic rule
@@ -101,7 +100,11 @@ function get_compartment_scaling(specie::String, formula::String, model_SBML::Mo
     end
 
     if model_SBML.species[specie].unit == :Concentration
-        return stoichiometry == false ? "/" * model_SBML.species[specie].compartment * "*" : "/" * model_SBML.species[specie].compartment 
+        if stoichiometry == false
+            return "/" * model_SBML.species[specie].compartment * "*"
+        else
+            return "/" * model_SBML.species[specie].compartment
+        end
     end
 end
 
@@ -110,36 +113,36 @@ function parse_stoichiometry(specie_reference::SBML.SpeciesReference, model_SBML
 
     mass_action_stoichiometry = isnothing(specie_reference.id)
     if !isnothing(specie_reference.id)
-        
-        if specie_reference.id ∈ keys(model_SBML.generated_ids)
+
+        if haskey(model_SBML.generated_ids, specie_reference.id)
             stoichiometry = model_SBML.generated_ids[specie_reference.id]
             return stoichiometry, mass_action_stoichiometry
 
-        # Two following special cases where the stoichiometry is given by another variable in the model             
+        # Two following special cases where the stoichiometry is given by another variable in the model
         elseif specie_reference.id ∈ model_SBML.rate_rule_variables
             return specie_reference.id, mass_action_stoichiometry
 
         elseif !isempty(model_SBML.events) && any(occursin.(specie_reference.id, reduce(vcat, [e.formulas for e in values(model_SBML.events)])))
             return specie_reference.id, mass_action_stoichiometry
         end
-        
+
         stoichiometry = specie_reference.id
-        # Here the stoichiometry is given as an assignment rule which has been interpreted as an additional model specie, 
+        # Here the stoichiometry is given as an assignment rule which has been interpreted as an additional model specie,
         # so the value is taken from the initial value
-        if stoichiometry ∈ keys(model_SBML.species) 
+        if haskey(model_SBML.species, stoichiometry)
             stoichiometry = model_SBML.species[stoichiometry].initial_value
             if is_number(stoichiometry)
                 stoichiometry = isnothing(stoichiometry) || stoichiometry == "nothing" ? "1" : stoichiometry
             end
-            # Can be nested 1 level 
-            if stoichiometry ∈ keys(model_SBML.species) && model_SBML.species[stoichiometry].assignment_rule == true
+            # Can be nested 1 level
+            if haskey(model_SBML.species, stoichiometry) && model_SBML.species[stoichiometry].assignment_rule == true
                 stoichiometry = model_SBML.species[stoichiometry].initial_value
             end
 
             return stoichiometry, mass_action_stoichiometry
         end
 
-        # Last case where stoichiometry is not referenced anywhere in the model assignments, rules etc..., assign 
+        # Last case where stoichiometry is not referenced anywhere in the model assignments, rules etc..., assign
         # to default value
         stoichiometry = string(specie_reference.stoichiometry)
 
@@ -159,12 +162,12 @@ function remove_stoichiometry_math_from_species!(model_SBML::ModelSBML, libsbml_
         specie_references = vcat([reactant for reactant in reaction.reactants], [product for product in reaction.products])
         for specie_reference in specie_references
 
-            if specie_reference.id ∈ keys(model_SBML.generated_ids) || isnothing(specie_reference.id)
+            if haskey(model_SBML.generated_ids, specie_reference.id) || isnothing(specie_reference.id)
                 continue
             end
 
             if specie_reference.id ∈ model_SBML.rate_rule_variables
-                if specie_reference.id ∈ keys(libsbml_model.initial_assignments)
+                if haskey(libsbml_model.initial_assignments, specie_reference.id)
                     continue
                 end
                 stoichiometry_t0 = isnothing(specie_reference.stoichiometry) ? "1.0" : string(specie_reference.stoichiometry)
@@ -177,11 +180,11 @@ function remove_stoichiometry_math_from_species!(model_SBML::ModelSBML, libsbml_
             end
 
             # An artifact from how the stoichiometry is procssed as assignment rule
-            # or initial assignment 
-            if specie_reference.id ∈ keys(model_SBML.species) 
+            # or initial assignment
+            if haskey(model_SBML.species, specie_reference.id)
                 delete!(model_SBML.species, specie_reference.id)
             end
-            if specie_reference.id ∈ model_SBML.assignment_rule_variables 
+            if specie_reference.id ∈ model_SBML.assignment_rule_variables
                 filter!(x -> x != specie_reference.id, model_SBML.assignment_rule_variables)
             end
         end

--- a/src/Rules.jl
+++ b/src/Rules.jl
@@ -44,7 +44,7 @@ function parse_assignment_rule!(model_SBML::ModelSBML, rule::SBML.AssignmentRule
 
     # Check if variable affects a specie, parameter or compartment. In case of specie the assignment rule takes 
     # priority over any potential reactions later.
-    if rule_variable ∈ keys(model_SBML.species)
+    if haskey(model_SBML.species, rule_variable)
         model_SBML.species[rule_variable].assignment_rule = true
         # If specie is given in amount account for the fact the that equation is given 
         # in conc. per SBML standard 
@@ -58,13 +58,13 @@ function parse_assignment_rule!(model_SBML::ModelSBML, rule::SBML.AssignmentRule
         end
         return nothing
     end
-    if rule_variable ∈ keys(model_SBML.parameters)
+    if haskey(model_SBML.parameters, rule_variable)
         model_SBML.parameters[rule_variable].assignment_rule = true
         model_SBML.parameters[rule_variable].formula = rule_formula
         model_SBML.parameters[rule_variable].initial_value = rule_formula
         return nothing
     end
-    if rule_variable ∈ keys(model_SBML.compartments)
+    if haskey(model_SBML.compartments, rule_variable)
         model_SBML.compartments[rule_variable].assignment_rule = true
         model_SBML.compartments[rule_variable].formula = rule_formula
         return nothing
@@ -111,7 +111,7 @@ function parse_rate_rule!(model_SBML::ModelSBML, rule::SBML.RateRule, libsbml_mo
         rule_formula = replace_variable(rule_formula, specie_id, "(" * specie_id * "/" * compartment * ")")
     end
 
-    if rule_variable ∈ keys(model_SBML.species)
+    if haskey(model_SBML.species, rule_variable)
         model_SBML.species[rule_variable].rate_rule = true
         # Must multiply with compartment if specie is given in amount as 
         # SBML formulas are given in conc. 
@@ -124,13 +124,13 @@ function parse_rate_rule!(model_SBML::ModelSBML, rule::SBML.RateRule, libsbml_mo
 
         return nothing
     end
-    if rule_variable ∈ keys(model_SBML.parameters)
+    if haskey(model_SBML.parameters, rule_variable)
         model_SBML.parameters[rule_variable].rate_rule = true
         model_SBML.parameters[rule_variable].initial_value = model_SBML.parameters[rule_variable].formula
         model_SBML.parameters[rule_variable].formula = rule_formula        
         return nothing
     end
-    if rule_variable ∈ keys(model_SBML.compartments)
+    if haskey(model_SBML.compartments, rule_variable)
         model_SBML.compartments[rule_variable].rate_rule = true
         model_SBML.compartments[rule_variable].initial_value = model_SBML.compartments[rule_variable].formula
         model_SBML.compartments[rule_variable].formula = rule_formula        

--- a/src/Rules.jl
+++ b/src/Rules.jl
@@ -23,7 +23,7 @@ end
 function parse_assignment_rule!(model_SBML::ModelSBML, rule::SBML.AssignmentRule, libsbml_model::SBML.Model)::Nothing
 
     rule_variable = rule.variable
-    rule_formula = parse_SBML_math(rule.math)
+    rule_formula, _ = parse_SBML_math(rule.math)
     rule_formula = replace_variable(rule_formula, "time", "t")
     rule_formula = SBML_function_to_math(rule_formula, model_SBML.functions)
 
@@ -90,7 +90,7 @@ end
 function parse_rate_rule!(model_SBML::ModelSBML, rule::SBML.RateRule, libsbml_model::SBML.Model)::Nothing
 
     rule_variable = rule.variable
-    rule_formula = parse_SBML_math(rule.math)
+    rule_formula, _ = parse_SBML_math(rule.math)
     rule_formula = replace_variable(rule_formula, "time", "t")    
     rule_formula = SBML_function_to_math(rule_formula, model_SBML.functions)
 
@@ -148,7 +148,7 @@ end
 
 
 function parse_algebraic_rule!(model_SBML::ModelSBML, rule::SBML.AlgebraicRule)::Nothing
-    rule_formula = parse_SBML_math(rule.math)
+    rule_formula, _ = parse_SBML_math(rule.math)
     if occursin("piecewise(", rule_formula)
         throw(SBMLSupport("Piecewise in algebraic rules is not supported"))
     end

--- a/src/SBMLImporter.jl
+++ b/src/SBMLImporter.jl
@@ -31,7 +31,6 @@ include("Math.jl")
 include("Initial_assignments.jl")
 include("Reactions.jl")
 
-
 # Model with piecewise for PrecompileTools to make model reading faster
 @setup_workload begin
     path_SBML = joinpath(@__DIR__, "..", "test", "Models", "model_Boehm_JProteomeRes2014.xml")

--- a/src/SBMLImporter.jl
+++ b/src/SBMLImporter.jl
@@ -34,7 +34,7 @@ include("Reactions.jl")
 # Model with piecewise for PrecompileTools to make model reading faster
 @setup_workload begin
     path_SBML = joinpath(@__DIR__, "..", "test", "Models", "model_Boehm_JProteomeRes2014.xml")
-    ode_system, specie_map, parameter_map, cb = SBML_to_ODESystem(path_SBML, ret_all=true, write_to_file=false)
+    ode_system, specie_map, parameter_map, cb = SBML_to_ODESystem(path_SBML, ret_all=true)
     ode_problem = ODEProblem(ode_system, specie_map, (0.0, 10.0), parameter_map, jac=true)
     sol = solve(ode_problem, Rodas5P(), abstol=1e-8, reltol=1e-8, callback=cb)
 end

--- a/src/SBML_to_ODESystem.jl
+++ b/src/SBML_to_ODESystem.jl
@@ -1,6 +1,7 @@
 """
     SBML_to_ODESystem(path_SBML::AbstractString;
                       ifelse_to_callback::Bool=true,
+                      inline_assignment_rules::Bool=false,
                       write_to_file::Bool=false,
                       verbose::Bool=true,
                       return_all::Bool=false,
@@ -20,6 +21,8 @@ For testing `path_SBML` can be the model as a string if `model_as_string=true`
 ## Arguments
 - `path_SBML`: File path to a valid SBML file (level 2 or higher).
 - `ifelse_to_callback=true`: Whether to rewrite `ifelse` (piecewise) expressions to callbacks; recommended for performance.
+- `inline_assignment_rules=true`: Whether to inline assignment rules into model equations. Recomended for model import speed, 
+    however, note that it will not be possible to access the rule-variable then via sol[:var]
 - `write_to_file=false`: Whether to write the parsed SBML model to a Julia file in the same directory as the SBML file.
 - `verbose=true`: Whether or not to display information on the number of return arguments.
 - `return_all=true`: Whether or not to return all possible arguments (see below), regardless of whether the model has events.

--- a/src/SBML_to_ODESystem.jl
+++ b/src/SBML_to_ODESystem.jl
@@ -59,89 +59,28 @@ sol = solve(prob, Rodas5P(), tstops=tstops, callback=callbacks)
 """
 function SBML_to_ODESystem(path_SBML::T;
                            ifelse_to_callback::Bool=true,
+                           inline_assignment_rules::Bool=true,
                            write_to_file::Bool=false,
                            verbose::Bool=true,
                            ret_all::Bool=false,
                            model_as_string::Bool=false) where T <: AbstractString
 
-    # Intermediate model representation of a SBML model which can be processed into
-    # an ODESystem
-    model_SBML = build_SBML_model(path_SBML; ifelse_to_callback=ifelse_to_callback, model_as_string=model_as_string)
-    rule_variables = unique(vcat(model_SBML.rate_rule_variables, model_SBML.assignment_rule_variables,
-                                 model_SBML.algebraic_rule_variables))
-
-    # If model is written to file save it in the same directory as the SBML-file
-    if model_as_string == false
-        dir_save = joinpath(splitdir(path_SBML)[1], "SBML")
-    else
-        dir_save = joinpath(@__DIR__, "SBML")
-    end
-    if write_to_file == true && !isdir(dir_save)
-        mkdir(dir_save)
-    end
-    path_save_model = joinpath(dir_save, model_SBML.name * ".jl")
-
-    # Build the ReactionSystem. Must be done via Meta-parse, because if a function is used 
-    # via @RuntimeGeneratedFunction runtime is very slow for large models
-    (_species_write, _specie_map_write, _variables_write, 
-     _parameters_write, _parameter_map_write, _reactions_write, 
-     no_species, integer_stoichiometries) = _reactionsystem_from_SBML(model_SBML, rule_variables)
-    # The model can have have only species or only variables or both. If it has variables they 
-    # are given via SBML rules
-    eval(Meta.parse("ModelingToolkit.@variables t"))
-    eval(Meta.parse("Differential(t)"))
-    sps = eval(Meta.parse(split(_species_write, "\n")[2]))
-    vs = isempty(rule_variables) ? Any[] : eval(Meta.parse(_variables_write))
-    if isempty(rule_variables)
-        sps_arg = sps
-    elseif no_species == false
-        sps_arg = [sps; vs]
-    else
-        sps_arg = vs
-    end                                  
-    # Parameters can not be an empty collection
-    if _parameters_write != "\tps = Catalyst.@parameters "
-        ps = eval(Meta.parse(_parameters_write))
-    else
-        ps = Any[]
-    end
-    _reactions = eval(Meta.parse(_reactions_write))
-    combinatoric_ratelaws = integer_stoichiometries ? true : false
-    # Build reaction system from its components
-    reaction_system = Catalyst.ReactionSystem(_reactions, t, sps_arg, ps; name=Symbol(model_SBML.name), combinatoric_ratelaws=combinatoric_ratelaws)
-    specie_map = eval(Meta.parse(_specie_map_write))
-    parameter_map = eval(Meta.parse(_parameter_map_write))
-    
-    # Build callback functions
-    cbset, callback_str = create_callbacks_SBML(reaction_system, model_SBML, model_SBML.name)
-    # Convert into an ODESystem
-    if isempty(model_SBML.algebraic_rules)
-        ode_system = structural_simplify(convert(ODESystem, reaction_system))
-    else
-        ode_system = structural_simplify(dae_index_lowering(convert(ODESystem, reaction_system)))
-    end
-
-    # if model is written to file write the callback
-    if write_to_file == true
-        path_save = joinpath(dir_save, model_SBML.name * "_callbacks.jl")
-        io = open(path_save, "w")
-        write(io, callback_str)
-        close(io)
-        _ = reactionsystem_to_string(_species_write, _specie_map_write, _variables_write, 
-                                     _parameters_write, _parameter_map_write, _reactions_write, 
-                                     no_species, integer_stoichiometries, write_to_file, path_save_model, 
-                                     rule_variables, model_SBML)
-    end
+    rn, specie_map, parameter_map, cb = SBML_to_ReactionSystem(path_SBML; ifelse_to_callback=ifelse_to_callback, 
+                                                               inline_assignment_rules=inline_assignment_rules, 
+                                                               write_to_file=write_to_file, 
+                                                               verbose=verbose, ret_all=true, 
+                                                               model_as_string=model_as_string)
+    sys = structural_simplify(convert(ODESystem, rn))
 
     if ret_all == true
-        return ode_system, specie_map, parameter_map, cbset
+        return sys, specie_map, parameter_map, cb
     end
 
     # Depending on model return what is needed to perform forward simulations
     if isempty(model_SBML.events) && isempty(model_SBML.ifelse_bool_expressions)
-        return ode_system, specie_map, parameter_map
+        return sys, specie_map, parameter_map
     end
-
+    
     verbose && @info "SBML model with events - output returned as odesys, specie_map, parameter_map, cbset\nFor how to simulate model see documentation"
-    return ode_system, specie_map, parameter_map, cbset
+    return sys, specie_map, parameter_map, cb
 end

--- a/src/SBML_to_ReactionSystem.jl
+++ b/src/SBML_to_ReactionSystem.jl
@@ -1,6 +1,7 @@
 """
     SBML_to_ReactionSystem(path_SBML::AbstractString;
                            ifelse_to_callback::Bool=true,
+                           inline_assignment_rules::Bool=false,
                            write_to_file::Bool=false, 
                            verbose::Bool=true, 
                            return_all::Bool=false, 
@@ -10,7 +11,7 @@ Parse an SBML model into a Catalyst `ReactionSystem` and potentially convert eve
 
 For information on simulating the `ReactionSystem`, refer to the documentation.
 
-For converting the SBML model directly into a ModelingToolkit `ODESystem` see the function `SBML_to_ReactionSystem`.
+For converting the SBML model directly into a ModelingToolkit `ODESystem` see the function `SBML_to_ODESystem`.
 
 For testing `path_SBML` can be the model as a string if `model_as_string=true`.
 
@@ -20,6 +21,8 @@ For testing `path_SBML` can be the model as a string if `model_as_string=true`.
 ## Arguments
 - `path_SBML`: File path to a valid SBML file (level 2 or higher).
 - `ifelse_to_callback=true`: Whether to rewrite `ifelse` (piecewise) expressions to callbacks; recommended for performance.
+- `inline_assignment_rules=true`: Whether to inline assignment rules into model equations. Recomended for model import speed, 
+    however, note that it will not be possible to access the rule-variable then via sol[:var]
 - `write_to_file=false`: Whether to write the parsed SBML model to a Julia file in the same directory as the SBML file.
 - `verbose=true`: Whether or not to display information on the number of return arguments.
 - `return_all=true`: Whether or not to return all possible arguments (see below), regardless of whether the model has events.

--- a/src/Species.jl
+++ b/src/Species.jl
@@ -170,7 +170,7 @@ function adjust_conversion_factor!(model_SBML::ModelSBML, libsbml_model::SBML.Mo
             continue
         end
 
-        if specie_id ∉ keys(libsbml_model.species)
+        if !haskey(libsbml_model.species, specie_id)
             continue
         end
 

--- a/src/Structs.jl
+++ b/src/Structs.jl
@@ -52,6 +52,8 @@ mutable struct ReactionSBML
     const reactants::Vector{String}
     const reactants_stoichiometry::Vector{String}
     const stoichiometry_mass_action::Bool
+    const has_assignment_rule_variable::Bool
+    const has_reaction_id::Bool
 end
 
 

--- a/src/Structs.jl
+++ b/src/Structs.jl
@@ -77,6 +77,7 @@ struct ModelSBML
     variables_with_piecewise::Vector{String}
     conversion_factor::String
     specie_reference_ids::Vector{String}
+    rule_variables::Vector{String}
 end
 function ModelSBML()::ModelSBML
     model_SBML = ModelSBML("",
@@ -96,8 +97,22 @@ function ModelSBML()::ModelSBML
                            Vector{String}(undef, 0), # Algebraic rule variables
                            Vector{String}(undef, 0), # Species_appearing in reactions
                            Vector{String}(undef, 0), 
-                           "") # Variables with piecewise
+                           "", 
+                           Vector{String}(undef, 0), 
+                           Vector{String}(undef, 0)) # Variables with piecewise
     return model_SBML                           
+end
+
+
+struct ModelSBMLString
+    species::String
+    specie_map::String
+    variables::String 
+    parameters::String 
+    parameter_map::String 
+    reactions::String   
+    no_species::Bool
+    int_stoichiometries::Bool
 end
 
 

--- a/src/Structs.jl
+++ b/src/Structs.jl
@@ -74,6 +74,7 @@ struct ModelSBML
     species_in_reactions::Vector{String}
     variables_with_piecewise::Vector{String}
     conversion_factor::String
+    specie_reference_ids::Vector{String}
 end
 function ModelSBML()::ModelSBML
     model_SBML = ModelSBML("",

--- a/test/Large_model.jl
+++ b/test/Large_model.jl
@@ -1,0 +1,17 @@
+#=
+    Test that import time for a larger model of 1265 species and 1000+ reactions
+=#
+
+using SBMLImporter
+using Downloads
+using Test
+
+
+#sbml_url = "https://raw.githubusercontent.com/SciML/Catalyst_PLOS_COMPBIO_2023/master/Benchmarks/Data/BCR_no_obs.xml"
+sbml_url = "https://www.ebi.ac.uk/biomodels/model/download/MODEL1112100000.2?filename=MODEL1112100000_url.xml"
+sbml_string = String(take!(Downloads.download(sbml_url, IOBuffer())))
+
+b1 = @elapsed rn, specie_map, parameter_map, cb = SBML_to_ReactionSystem(sbml_string; model_as_string=true, ret_all=true)
+
+# Usually takes around 4s locally, but better to brace for GitHub CI
+@test b1 ≤ 20

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using SafeTestsets
 
+@safetestset "SBML large model" begin
+    include("Large_model.jl")
+end
+
 @safetestset "SBML semantic test-suite" begin
     include("Testsuite_catalyst.jl")
 end


### PR DESCRIPTION
Refactor code to faster import large SBML models (> 1000 species). 

SBML identifiers are now extracted when parsing the math. Thus we must no longer recheck that a formula has for example a reaction-id which drastically speed up parsing for models with many reactions. Moreover, the `ReactionSystem` is no longer generated via a `RuntimeGeneratedFunction` as this, somehow, drastically increased runtime. To keep a tab on this, added a test to further check that import is not too slow. Now the species, parameters and reactions are evaluated via `Meta.parse` and then provided to the `ReactionSystem` constructor. Lastly, assignment rules can cause a stack-overflow for large models. This is now avoided by in-lining assignment rules in the reactions.

Closes #24 