### PR TITLE
Fix load bug for large models

### DIFF
--- a/test/Large_model.jl
+++ b/test/Large_model.jl
@@ -13,3 +13,9 @@ b1 = @elapsed parsed_rn, cb = load_SBML(sbml_string; model_as_string = true)
 
 # Usually takes around 4s locally, but better to brace for GitHub CI
 @test b1 ≤ 20
+
+# Large fceri-γ model with ≈ 58,000 reactions. Should take around 4min locally, but it
+# is always good to brace for GitHub CI
+path_SBML = joinpath(@__DIR__, "Models", "fceri_gamma2.xml")
+b2 = @elapsed parsed_rn, cb = load_SBML(path_SBML)
+@test b2 ≤ 500


### PR DESCRIPTION
Before all reactions were collected in a vector. For models with more than 58,000 reactions this caused stackoverflow, now reactions are added one at a time with `addreaction!`.