### PR TITLE
Add option to not inline kinetic law parameters in SBML reactions

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -1,3 +1,8 @@
+function _isequal(x1::T, x2::T)::Bool where {T <: VariableSBML}
+    f = fieldnames(T)
+    return getfield.(Ref(x1), f) == getfield.(Ref(x2), f)
+end
+
 function _replace_variable(formula::AbstractString, to_replace::String,
                            replace_with::String)::String
     if !occursin(to_replace, formula)

--- a/src/load.jl
+++ b/src/load.jl
@@ -27,7 +27,13 @@ check if a model follows mass action kinetics, see the FAQ in the documentation.
 - `inline_assignment_rules::Bool=false`: Inline SBML assignment rules into model equations.
     Recommended for importing large models. **However**, if set to `true`, it is
     not possible to access assignment rule variables via `sol[:var]`.
-- `write_to_file::Bool=false`: Write the parsed SBML model to a Julia file in the same
+- `inline_kineticlaw_parameters::Bool=true`: Inline (hardcode) SBML kinetic law parameter
+    values into the model equations. Kinetic law parameters are parameters defined only in
+    the kinetic law field of an SBML reaction. It is recommended to inline them as there
+    might be duplicate IDs, e.g., the same kinetic law parameter redefined for different
+    reactions. If they are not inlined, they are promoted to model parameters (with the
+    same status as parameters in the SBML file).
+- `write_to_file=false`: Write the parsed SBML model to a Julia file in the same
     directory as the SBML file.
 - `model_as_string::Bool=false`: Whether the model (`path`) is provided as a string.
 
@@ -68,10 +74,12 @@ sol = solve(oprob, Rodas5P(), callback=cb)
 function load_SBML(path::AbstractString; massaction::Bool = false, complete::Bool = true,
                    ifelse_to_callback::Bool = true, write_to_file::Bool = false,
                    inline_assignment_rules::Bool = false,
+                   inline_kineticlaw_parameters::Bool = true,
                    model_as_string::Bool = false)::Tuple{ParsedReactionNetwork, CallbackSet}
     model_SBML = parse_SBML(path, massaction; ifelse_to_callback = ifelse_to_callback,
                             model_as_string = model_as_string,
-                            inline_assignment_rules = inline_assignment_rules)
+                            inline_assignment_rules = inline_assignment_rules,
+                            inline_kineticlaw_parameters = inline_kineticlaw_parameters)
     model_SBML_sys = _to_system_syntax(model_SBML, inline_assignment_rules, massaction)
     rn, specie_map, parameter_map = _get_reaction_system(model_SBML_sys, model_SBML.name)
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -1,15 +1,17 @@
 function parse_parameters!(model_SBML::ModelSBML, libsbml_model::SBML.Model)::Nothing
     for (parameter_id, parameter) in libsbml_model.parameters
-        if parameter_id in FORBIDDEN_IDS
-            throw(SBMLSupport("Parameter name $(parameter_id) is not allowed."))
-        end
-
-        formula = _parse_variable(parameter.value; default = "0.0")
-        constant = _parse_bool(parameter.constant)
-        initial_value = ""
-        model_SBML.parameters[parameter_id] = ParameterSBML(parameter_id, constant, formula,
-                                                            initial_value, false, false,
-                                                            false, false, false, false)
+        model_SBML.parameters[parameter_id] = _parse_parameter(parameter_id, parameter)
     end
     return nothing
+end
+
+function _parse_parameter(parameter_id::String, parameter::SBML.Parameter)::ParameterSBML
+    if parameter_id in FORBIDDEN_IDS
+        throw(SBMLSupport("Parameter name $(parameter_id) is not allowed."))
+    end
+    formula = _parse_variable(parameter.value; default = "0.0")
+    constant = _parse_bool(parameter.constant)
+    initial_value = ""
+    return ParameterSBML(parameter_id, constant, formula, initial_value, false, false,
+                         false, false, false, false)
 end

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -7,7 +7,8 @@ to create a ReactionSystem.
 For testing path can be the model as a string if model_as_string=true.
 """
 function parse_SBML(path::String, massaction::Bool; ifelse_to_callback::Bool = true,
-                    model_as_string = true, inline_assignment_rules::Bool = true)::ModelSBML
+                    model_as_string = true, inline_assignment_rules::Bool = true,
+                    inline_kineticlaw_parameters::Bool = true)::ModelSBML
     model_str = _get_model_as_str(path, model_as_string)
     check_support(path)
 
@@ -24,11 +25,12 @@ function parse_SBML(path::String, massaction::Bool; ifelse_to_callback::Bool = t
     end
 
     return _parse_SBML(libsbml_model, ifelse_to_callback, inline_assignment_rules,
-                       massaction)
+                       inline_kineticlaw_parameters, massaction)
 end
 
 function _parse_SBML(libsbml_model::SBML.Model, ifelse_to_callback::Bool,
-                     inline_assignment_rules::Bool, massaction::Bool)::ModelSBML
+                     inline_assignment_rules::Bool, inline_kineticlaw_parameters::Bool,
+                     massaction::Bool)::ModelSBML
     model_SBML = ModelSBML(libsbml_model)
 
     parse_species!(model_SBML, libsbml_model, massaction)
@@ -45,7 +47,7 @@ function _parse_SBML(libsbml_model::SBML.Model, ifelse_to_callback::Bool,
 
     parse_initial_assignments!(model_SBML, libsbml_model)
 
-    parse_reactions!(model_SBML, libsbml_model)
+    parse_reactions!(model_SBML, libsbml_model, inline_kineticlaw_parameters)
 
     # Following the SBML standard reaction ids can appear in formulas, where they correspond
     # to the reaction kinetic_math expression

--- a/test/Models/brusselator_kinetic_parameters.xml
+++ b/test/Models/brusselator_kinetic_parameters.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by COPASI version 4.42 (Build 284) on 2024-01-10 09:22 with libSBML version 5.20.0. -->
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4">
+  <model metaid="COPASI0" id="New_Model" name="New Model">
+    <annotation>
+      <copasi:COPASI xmlns:copasi="http://www.copasi.org/static/sbml">
+        <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+          <rdf:Description rdf:about="#COPASI0">
+            <dcterms:created>
+              <rdf:Description>
+                <dcterms:W3CDTF>2024-01-09T21:46:45Z</dcterms:W3CDTF>
+              </rdf:Description>
+            </dcterms:created>
+          </rdf:Description>
+        </rdf:RDF>
+      </copasi:COPASI>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+        <rdf:Description rdf:about="#COPASI0">
+          <dcterms:created rdf:parseType="Resource">
+            <dcterms:W3CDTF>2024-01-09T21:46:45Z</dcterms:W3CDTF>
+          </dcterms:created>
+          <dcterms:modified rdf:parseType="Resource">
+            <dcterms:W3CDTF>2024-01-09T21:46:45Z</dcterms:W3CDTF>
+          </dcterms:modified>
+        </rdf:Description>
+      </rdf:RDF>
+    </annotation>
+    <listOfFunctionDefinitions>
+      <functionDefinition id="Constant_flux__irreversible" name="Constant flux (irreversible)">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> v </ci>
+            </bvar>
+            <ci> v </ci>
+          </lambda>
+        </math>
+      </functionDefinition>
+    </listOfFunctionDefinitions>
+    <listOfUnitDefinitions>
+      <unitDefinition id="length" name="length">
+        <listOfUnits>
+          <unit kind="metre" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="area" name="area">
+        <listOfUnits>
+          <unit kind="metre" exponent="2" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="volume" name="volume">
+        <listOfUnits>
+          <unit kind="litre" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="time" name="time">
+        <listOfUnits>
+          <unit kind="second" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="substance" name="substance">
+        <listOfUnits>
+          <unit kind="mole" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment id="compartment" name="compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="X" name="X" compartment="compartment" hasOnlySubstanceUnits="true" initialAmount="2" boundaryCondition="false" constant="false"/>
+      <species id="Y" name="Y" compartment="compartment" hasOnlySubstanceUnits="true" initialAmount="10" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="A" name="A" value="1" constant="true"/>
+      <parameter id="B" name="B" value="4" constant="true"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction id="r2_id" name="r2_name" reversible="false">
+        <listOfReactants>
+          <speciesReference species="Y" stoichiometry="1"/>
+          <speciesReference species="X" stoichiometry="2"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="X" stoichiometry="3"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> compartment </ci>
+              <ci> k1_r2 </ci>
+              <apply>
+                <power/>
+                <ci> X </ci>
+                <cn> 2 </cn>
+              </apply>
+              <ci> Y </ci>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter id="k1_r2" name="k1_r2" value="1"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="r3_id" name="r3_name" reversible="false">
+        <listOfReactants>
+          <speciesReference species="X" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="Y" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> compartment </ci>
+              <ci> B </ci>
+              <ci> X </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="r4_id" name="r4_name" reversible="false">
+        <listOfReactants>
+          <speciesReference species="X" stoichiometry="1"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> compartment </ci>
+              <ci> k1_r4 </ci>
+              <ci> X </ci>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter id="k1_r4" name="k1_r4" value="1"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="r1_id" name="r1_name" reversible="false">
+        <listOfProducts>
+          <speciesReference species="X" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> compartment </ci>
+              <apply>
+                <ci> Constant_flux__irreversible </ci>
+                <ci> A </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/Models/brusselator_kinetic_parameters_fail.xml
+++ b/test/Models/brusselator_kinetic_parameters_fail.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by COPASI version 4.42 (Build 284) on 2024-01-10 09:22 with libSBML version 5.20.0. -->
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4">
+  <model metaid="COPASI0" id="New_Model" name="New Model">
+    <annotation>
+      <copasi:COPASI xmlns:copasi="http://www.copasi.org/static/sbml">
+        <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+          <rdf:Description rdf:about="#COPASI0">
+            <dcterms:created>
+              <rdf:Description>
+                <dcterms:W3CDTF>2024-01-09T21:46:45Z</dcterms:W3CDTF>
+              </rdf:Description>
+            </dcterms:created>
+          </rdf:Description>
+        </rdf:RDF>
+      </copasi:COPASI>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+        <rdf:Description rdf:about="#COPASI0">
+          <dcterms:created rdf:parseType="Resource">
+            <dcterms:W3CDTF>2024-01-09T21:46:45Z</dcterms:W3CDTF>
+          </dcterms:created>
+          <dcterms:modified rdf:parseType="Resource">
+            <dcterms:W3CDTF>2024-01-09T21:46:45Z</dcterms:W3CDTF>
+          </dcterms:modified>
+        </rdf:Description>
+      </rdf:RDF>
+    </annotation>
+    <listOfFunctionDefinitions>
+      <functionDefinition id="Constant_flux__irreversible" name="Constant flux (irreversible)">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> v </ci>
+            </bvar>
+            <ci> v </ci>
+          </lambda>
+        </math>
+      </functionDefinition>
+    </listOfFunctionDefinitions>
+    <listOfUnitDefinitions>
+      <unitDefinition id="length" name="length">
+        <listOfUnits>
+          <unit kind="metre" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="area" name="area">
+        <listOfUnits>
+          <unit kind="metre" exponent="2" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="volume" name="volume">
+        <listOfUnits>
+          <unit kind="litre" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="time" name="time">
+        <listOfUnits>
+          <unit kind="second" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="substance" name="substance">
+        <listOfUnits>
+          <unit kind="mole" exponent="1" scale="0" multiplier="1"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment id="compartment" name="compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="X" name="X" compartment="compartment" hasOnlySubstanceUnits="true" initialAmount="2" boundaryCondition="false" constant="false"/>
+      <species id="Y" name="Y" compartment="compartment" hasOnlySubstanceUnits="true" initialAmount="10" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="A" name="A" value="1" constant="true"/>
+      <parameter id="B" name="B" value="4" constant="true"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction id="r2_id" name="r2_name" reversible="false">
+        <listOfReactants>
+          <speciesReference species="Y" stoichiometry="1"/>
+          <speciesReference species="X" stoichiometry="2"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="X" stoichiometry="3"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> compartment </ci>
+              <ci> k1 </ci>
+              <apply>
+                <power/>
+                <ci> X </ci>
+                <cn> 2 </cn>
+              </apply>
+              <ci> Y </ci>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter id="k1" name="k1" value="2"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="r3_id" name="r3_name" reversible="false">
+        <listOfReactants>
+          <speciesReference species="X" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="Y" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> compartment </ci>
+              <ci> B </ci>
+              <ci> X </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="r4_id" name="r4_name" reversible="false">
+        <listOfReactants>
+          <speciesReference species="X" stoichiometry="1"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> compartment </ci>
+              <ci> k1 </ci>
+              <ci> X </ci>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter id="k1" name="k1" value="1"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction id="r1_id" name="r1_name" reversible="false">
+        <listOfProducts>
+          <speciesReference species="X" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> compartment </ci>
+              <apply>
+                <ci> Constant_flux__irreversible </ci>
+                <ci> A </ci>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/kineticlaw_parameters.jl
+++ b/test/kineticlaw_parameters.jl
@@ -1,0 +1,34 @@
+using SBMLImporter, Catalyst, OrdinaryDiffEq, Test
+
+#=
+    Test that if kinetic law parameters are inlined correctly if the user selects that
+    option. Further, tests different duplicate id cases.
+=#
+
+# First case with no duplicate ids
+path_SBML = joinpath(@__DIR__, "Models", "brusselator_kinetic_parameters.xml")
+prn1, cb1 = load_SBML(path_SBML; inline_kineticlaw_parameters = false)
+@test string.(parameters(prn1.rn)) == ["B", "A", "k1_r2", "k1_r4", "compartment"]
+@test string(prn1.p[3]) == "k1_r2 => 1.0"
+@test string(prn1.p[4]) == "k1_r4 => 1.0"
+prn2, cb2 = load_SBML(path_SBML; inline_kineticlaw_parameters = true)
+@test string.(parameters(prn2.rn)) == ["B", "A", "compartment"]
+oprob1 = ODEProblem(prn1.rn, prn1.u0, (0.0, 10.0), prn1.p)
+sol1 = solve(oprob1, Rodas5P())
+oprob2 = ODEProblem(prn2.rn, prn2.u0, (0.0, 10.0), prn2.p)
+sol2 = solve(oprob2, Rodas5P())
+@test sum(reduce(vcat, sol1.u .- sol2.u).^2) ≤ 1e-10
+
+# With duplicate id parameters, wherse the parameters have the same value and therefore
+# the model can be imported
+path_SBML = joinpath(@__DIR__, "Models", "brusselator.xml")
+prn, cb = load_SBML(path_SBML; inline_kineticlaw_parameters = false)
+@test string.(parameters(prn.rn)) == ["B", "A", "k1", "compartment"]
+@test string(prn.p[3]) == "k1 => 1.0"
+
+# With duplicate id parameters, wherse the parameters have the same value and therefore
+# the model can be imported
+path_SBML = joinpath(@__DIR__, "Models", "brusselator_kinetic_parameters_fail.xml")
+@test_throws SBMLImporter.SBMLSupport begin
+    prn, cb = load_SBML(path_SBML; inline_kineticlaw_parameters = false)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,10 @@ end
     include("inline_assignment_rules.jl")
 end
 
+@safetestset "Kinetic law parameters" begin
+    include("kineticlaw_parameters.jl")
+end
+
 @safetestset "Ifelse to callback" begin
     include("ifelse_to_callback.jl")
 end


### PR DESCRIPTION
Kinetic law parameters are parameters that only appear in the kinetic law field of a SBML reaction. By default the values for these are inlined, but this adds the option to not inline them but rather promote to the same status as an SBML parameter via the `inline_kineticlaw_parameters` keyword in `load_SBML`.