### PR TITLE
Update for PEtab v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "SBMLImporter"
 uuid = "210efffb-c3c8-456d-a807-6f55560b12fe"
-version = "1.2.0"
+version = "2.3.0"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JumpProcesses = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
@@ -15,6 +16,12 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
+[weakdeps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+
+[extensions]
+SBMLImporterForwardDiffExt = ["ForwardDiff"]
+
 [compat]
 Aqua = "0.8"
 CSV = "0.10"
@@ -22,6 +29,7 @@ Catalyst = "14"
 DataFrames = "1.6"
 DiffEqBase = "6"
 Downloads = "1"
+ForwardDiff = "0.10"
 JumpProcesses = "9"
 ModelingToolkit = "9"
 OrdinaryDiffEq = "6"

--- a/ext/SBMLImporterForwardDiffExt.jl
+++ b/ext/SBMLImporterForwardDiffExt.jl
@@ -1,0 +1,15 @@
+module SBMLImporterForwardDiffExt
+
+using ForwardDiff
+using SBMLImporter
+
+"""
+    dual_to_float(x::ForwardDiff.Dual)::AbstractFloat
+
+Via recursion convert a Dual to a Float.
+"""
+function SBMLImporter._to_float(x::ForwardDiff.Dual)::AbstractFloat
+    return SBMLImporter._to_float(x.value)
+end
+
+end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -107,30 +107,30 @@ struct ModelSBML
     reactionids::Vector{String}
 end
 function ModelSBML(name::String; specie_reference_ids::Vector{String} = String[],
-                   conversion_factor::String = "",
+                   conversion_factor::String = "", events = Dict{String, EventSBML}(),
                    libsbml_rule_variables::Vector{String} = String[],
                    reactionids::Vector{String} = String[])::ModelSBML
     model_SBML = ModelSBML(name,
                            Dict{String, SpecieSBML}(),
                            Dict{String, ParameterSBML}(),
                            Dict{String, CompartmentSBML}(),
-                           Dict{String, EventSBML}(),
+                           events,
                            Dict{String, ReactionSBML}(),
-                           Dict{String, FunctionSBML}(), # SBML reactions
-                           Dict{String, String}(), # Algebraic rules
-                           Dict{String, String}(), # Generated id:s
-                           Dict{String, String}(), # Piecewise to ifelse_expressions
-                           Dict{String, String}(), # Ifelse to bool expression
-                           String[], # Rate rule variables
-                           String[], # Assignment rule variables
-                           String[], # Algebraic rule variables
-                           String[], # Species_appearing in reactions
+                           Dict{String, FunctionSBML}(),
+                           Dict{String, String}(),
+                           Dict{String, String}(),
+                           Dict{String, String}(),
+                           Dict{String, String}(),
+                           String[],
+                           String[],
+                           String[],
+                           String[],
                            String[],
                            conversion_factor,
                            specie_reference_ids,
                            String[],
                            libsbml_rule_variables,
-                           reactionids) # Variables with piecewise
+                           reactionids)
     return model_SBML
 end
 function ModelSBML(libsbml_model::SBML.Model)::ModelSBML


### PR DESCRIPTION
For PEtab.jl v3 callback handling will be entirely done by SBMLImporter. To this end SBMLImporter must know the parameter order, and whether or not `tspan` should be converted to floats. The latter matters if the trigger time (`tstops`) depends on parameters, in some cases we must convert the `tspan` to `ForwardDiff.Dual` for correct gradients, while sometimes the `tspan` should be floats and therefore also the `tstops`.