### PR TITLE
Update to use new Symbolics solvers

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -147,8 +147,9 @@ function _get_tstops(model_SBML::ModelSBML, specie_ids::Vector{String},
         condition_symbolic = eval(Meta.parse(condition))
         local tstop
         try
-            tstop = string.(Symbolics.solve_for(condition_symbolic, variables_symbolic[1],
-                                                simplify = true))
+            tstop = string.(Symbolics.symbolic_linear_solve(condition_symbolic,
+                                                            variables_symbolic[1],
+                                                            simplify = true))
         catch
             throw(SBMLSupport("Not possible to solve for time event $(event.name) is activated"))
         end

--- a/src/events.jl
+++ b/src/events.jl
@@ -152,7 +152,7 @@ function force_include_event_variables!(model_SBML::ModelSBML)::Nothing
         variable.algebraic_rule == true && continue
         !is_number(variable.formula) && continue
         parse(Float64, variable.formula) ≈ π && continue # To pass test case 957
-
+        variable.assignment_rule = false
         variable.rate_rule = true
         variable.initial_value = variable.formula
         variable.formula = "0.0"

--- a/src/system.jl
+++ b/src/system.jl
@@ -163,7 +163,7 @@ function _get_system_variables(model_SBML::ModelSBML,
         end
         mtk_variables *= variable_id * "(t) "
         if !(variable_id in model_SBML.algebraic_rule_variables) &&
-             variable.assignment_rule == false
+           variable.assignment_rule == false
             specie_map *= _template_value_map(variable_id, variable.initial_value)
         end
     end

--- a/src/system.jl
+++ b/src/system.jl
@@ -162,7 +162,8 @@ function _get_system_variables(model_SBML::ModelSBML,
             continue
         end
         mtk_variables *= variable_id * "(t) "
-        if !(variable_id in model_SBML.algebraic_rule_variables)
+        if !(variable_id in model_SBML.algebraic_rule_variables) &&
+             variable.assignment_rule == false
             specie_map *= _template_value_map(variable_id, variable.initial_value)
         end
     end


### PR DESCRIPTION
The old Symbolics.jl solver is no longer recommended, and causes warnings to be printed in SBMLImporter and in PEtab. 