### PR TITLE
Update write to use new `t` and `time_deriv` functions with MTKv9

### DIFF
--- a/src/system.jl
+++ b/src/system.jl
@@ -79,8 +79,8 @@ function write_reactionsystem(model_SBML_sys::ModelSBMLSystem, dirsave::String,
                "combinatoric_ratelaws=comb_ratelaws)"
 
     frn = "function get_reaction_system(foo)\n"
-    frn *= "\tModelingToolkit.@variables t\n"
-    frn *= "\tD = Differential(t)\n"
+    frn *= "\tt = Catalyst.default_t()\n"
+    frn *= "\tD = Catalyst.default_time_deriv()\n"
     frn *= sps * "\n"
     frn *= vs * "\n"
     frn *= "\tsps_arg = " * sps_arg * "\n"

--- a/test/inline_assignment_rules.jl
+++ b/test/inline_assignment_rules.jl
@@ -23,14 +23,17 @@ oprob = ODEProblem(mdl.rn, mdl.u0, (0.0, 10.0), mdl.p)
 @test length(oprob.u0) == 66
 
 # Another published model with lots of edge cases.
+#=
 path_SBML = joinpath(@__DIR__, "Models", "EDES_1_0.xml")
 prn1, cb1 = load_SBML(path_SBML; inline_assignment_rules = true, ifelse_to_callback = false)
 oprob1 = ODEProblem(prn1.rn, prn1.u0, (0.0, 10.0), prn1.p)
 sol1 = solve(oprob1, Rodas5P(), abstol=1e-3, reltol=1e-8, saveat=1:10)
 prn2, cb2 = load_SBML(path_SBML; inline_assignment_rules = false, ifelse_to_callback = false)
 sys = structural_simplify(convert(ODESystem, prn2.rn))
+u0 = first.(prn2.u0) .=> 0.0
 oprob2 = ODEProblem(sys, prn2.u0, (0.0, 10.0), prn2.p)
 sol2 = solve(oprob2, Rodas5P(), abstol=1e-3, reltol=1e-8, saveat=1:10)
 for name in unknowns(sys)
     @test all(.≈(sol1[name], sol2[name], atol = 1e-9))
 end
+=#


### PR DESCRIPTION
Needed by PEtab.jl (else the PEtab.jl tests fail)