### PR TITLE
Change from D to Differential for Catalyst.default_time_deriv()

### DIFF
--- a/src/SBMLImporter.jl
+++ b/src/SBMLImporter.jl
@@ -20,7 +20,7 @@ include("structs.jl")
 const SBMLMathVariables = Union{SBML.MathIdent, SBML.MathVal, SBML.MathTime, SBML.MathConst,
                                 SBML.MathAvogadro}
 const SBMLRule = Union{SBML.AssignmentRule, SBML.RateRule, SBML.AlgebraicRule}
-const FORBIDDEN_IDS = ["true", "false", "time", "pi", "Inf", "NaN"]
+const FORBIDDEN_IDS = ["true", "false", "time", "pi", "Inf", "NaN", "Differential"]
 const VariableSBML = Union{SpecieSBML, ParameterSBML, CompartmentSBML}
 
 include("callbacks.jl")

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -189,9 +189,10 @@ function _ids_to_cb_syntax(formula::String, ids::Vector{String}, id_type::Symbol
     # PEtab.jl cannot interact with SciMLStructures yet due to SciMLSensitivity. Therefore
     # for parameters the old integrator.p must be used (this will be fixed later for PEtab),
     # and the parameter order in p_PEtab must be used for correct mappings
-    for (i, id) in pairs(ids)
+    for id in ids
         if id_type == :specie
-            replace_with = utmp ? "utmp[" * string(i) * "]" : "u[" * string(i) * "]"
+            index = "ModelingToolkit.getu(integrator, :$id).idx"
+            replace_with = utmp ? "utmp[$index]" : "u[$index]"
         elseif id_type == :parameter && isnothing(p_PEtab)
             replace_with = "ps[:" * id * "]"
         elseif id_type == :parameter && !isnothing(p_PEtab)

--- a/src/system.jl
+++ b/src/system.jl
@@ -3,7 +3,7 @@ function _get_reaction_system(model_SBML_sys::ModelSBMLSystem, model_SBML::Model
     # The ReactionSystem must be built via eval, as creating a function that returns
     # the rn fails for large models
     eval(Meta.parse("t = Catalyst.default_t()"))
-    eval(Meta.parse("D = Catalyst.default_time_deriv()"))
+    eval(Meta.parse("Differential = Catalyst.default_time_deriv()"))
     # A model must have either variables or species, which dictates the sps call to
     # the reaction system
     if model_SBML_sys.has_species == true
@@ -80,7 +80,7 @@ function write_reactionsystem(model_SBML_sys::ModelSBMLSystem, dirsave::String,
 
     frn = "function get_reaction_system(foo)\n"
     frn *= "\tt = Catalyst.default_t()\n"
-    frn *= "\tD = Catalyst.default_time_deriv()\n"
+    frn *= "\tDifferential = Catalyst.default_time_deriv()\n"
     frn *= sps * "\n"
     frn *= vs * "\n"
     frn *= "\tsps_arg = " * sps_arg * "\n"

--- a/src/templates.jl
+++ b/src/templates.jl
@@ -8,7 +8,7 @@ function _template_value_map(id::String, value::String)::String
 end
 
 function _template_rate_rule(id::String, formula::String)::String
-    return "\t\tD(" * id * ") ~ " * formula * ",\n"
+    return "\t\tDifferential(" * id * ") ~ " * formula * ",\n"
 end
 
 function _template_assignment_rule(id::String, formula::String)::String


### PR DESCRIPTION
Models are allowed to have variables named `D`, which since `Catalyst.default_time_deriv()` is mapped to `D` can cause problems. Therefore, `Catalyst.default_time_deriv()` is now mapped to `Differential`.

Closes #100 