### PR TITLE
Run CI weekly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,8 @@ on:
       - main
     tags: ['*']
   pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.


### PR DESCRIPTION
As the SciML ecosystem moves rapidly, it is beneficial to run the CI tests weekly to ensure nothing is broken with the package.