### PR TITLE
Fixes #168: ifelse_to_callback = true fix

### DIFF
--- a/src/piecewise.jl
+++ b/src/piecewise.jl
@@ -116,8 +116,8 @@ end
 function _template_bool_picewise(
         bool_name::String, ifelse_arg1::String, ifelse_arg2::String, side_activated::String
     )::String
-    activated = side_activated == "right" ? ifelse_arg1 : ifelse_arg2
-    deactivated = side_activated == "right" ? ifelse_arg2 : ifelse_arg1
+    activated = side_activated == "left" ? ifelse_arg1 : ifelse_arg2
+    deactivated = side_activated == "left" ? ifelse_arg2 : ifelse_arg1
     formula = "((1 - 1" * bool_name * ") * (" * deactivated * ") + " *
         bool_name * "*(" * activated * "))"
     return formula
@@ -129,6 +129,11 @@ function _get_sign_time(formula::String)::Int64
     _formula = _find_term_with_t(formula)
     @assert !isempty(_formula) "In $formula for condition in piecewise cannot identify \
         which term time appears in."
+
+    if startswith(_formula, "-(") && occursin(",", _formula)
+        a = split(_formula[3:(end - 1)], ","; limit = 2)[1]
+        return _has_time(String(a)) ? 1 : -1
+    end
 
     _formula = replace(_formula, "(" => "", ")" => "")
     if _formula == "t"
@@ -183,7 +188,7 @@ function _ifelse_to_event(id::String, condition::String, side_activated)::EventS
     # condition, as otherwise we mess up callback initialization where the bool variable
     # is set to 1 if the condition is true. It is also important to work with strict
     # inequality here to handle any edge-cases where the trigger time is t = 0
-    if side_activated == "left"
+    if side_activated == "right"
         if any(occursin.(["<", "≤", "<="], condition))
             condition = replace(condition, r"≤|<=|<" => "≥")
         else

--- a/src/piecewise.jl
+++ b/src/piecewise.jl
@@ -150,7 +150,6 @@ function _get_sign_time(formula::String)::Int64
         happens if the formula contains a minus sign in the term where t appears."
     throw(SBMLSupport(str_write))
 end
-
 """
     _get_sign_time(expr)::Union{Int64, Nothing}
 

--- a/src/piecewise.jl
+++ b/src/piecewise.jl
@@ -124,60 +124,106 @@ function _template_bool_picewise(
 end
 
 function _get_sign_time(formula::String)::Int64
-    formula = replace(formula, " " => "")
-    formula = _trim_paranthesis(formula)
-    _formula = _find_term_with_t(formula)
-    @assert !isempty(_formula) "In $formula for condition in piecewise cannot identify \
-        which term time appears in."
-
-    if startswith(_formula, "-(") && occursin(",", _formula)
-        a = split(_formula[3:(end - 1)], ","; limit = 2)[1]
-        return _has_time(String(a)) ? 1 : -1
+    # Math expressions are stored in prefix notation (e.g. -(t, 5.0)). Meta.parse handles
+    # both prefix and infix notation, which allows the direction to be inferred from the
+    # expression tree
+    expr = try
+        Meta.parse(formula)
+    catch
+        nothing
+    end
+    if !(expr isa Expr && expr.head in [:error, :incomplete])
+        sign_time = _get_sign_time(expr)
+        !isnothing(sign_time) && return sign_time
     end
 
-    _formula = replace(_formula, "(" => "", ")" => "")
-    if _formula == "t"
-        return 1
-    elseif length(_formula) ≥ 2 && _formula[1:2] == "-t"
-        return -1
-    elseif length(_formula) ≥ 3 && _formula[1:3] == "--t"
-        return 1
-    elseif length(_formula) ≥ 3 && (_formula[1:3] == "+-t" || _formula[1:3] == "-+t")
-        return -1
-    end
-
-    # If '-' appears anywhere after the cases above we might be able to infer direction,
-    # but infering in this situation is hard! - so throw an error as the user should
-    # be able to write condition in a more easy manner (avoid several sign changing minus signs)
-    !occursin('-', _formula) && return 1
+    # If a '-' does not appear in the formula the expression must increase with time. This
+    # covers expressions the analysis above cannot handle (e.g. exp(t)). If a '-' appears
+    # we might be able to infer direction, but infering in this situation is hard! - so
+    # throw an error as the user should be able to write condition in a more easy manner
+    # (avoid several sign changing minus signs)
+    !occursin('-', formula) && return 1
     str_write = "For piecewise with time in condition we cannot infer direction for \
         $formula, that is if the condition value increases or decreases with time. This \
         happens if the formula contains a minus sign in the term where t appears."
     throw(SBMLSupport(str_write))
 end
 
-function _find_term_with_t(formula::String)::String
-    formula == "t" && return formula
-    istart, parenthesis_level, term = 1, 0, ""
-    for (i, char) in pairs(formula)
-        if i == 1 && char in ['+', '-']
-            continue
-        end
-        parenthesis_level = char == '(' ? parenthesis_level + 1 : parenthesis_level
-        parenthesis_level = char == ')' ? parenthesis_level - 1 : parenthesis_level
-        if !(parenthesis_level == 0 && (char in ['+', '-'] || i == length(formula)))
-            continue
-        end
-        if formula[i - 1] in ['+', '-'] && i != length(formula)
-            continue
-        end
-        term = formula[istart:i]
-        if _has_time(term) == true || (i == length(formula) && char == 't')
-            return term[end] in ['+', '-'] ? term[1:(end - 1)] : term
-        end
-        istart = i
+"""
+    _get_sign_time(expr)::Union{Int64, Nothing}
+
+Infer whether a Julia expression increases (`1`) or decreases (`-1`) with time.
+
+If the direction cannot be inferred `nothing` is returned.
+"""
+function _get_sign_time(expr)::Union{Int64, Nothing}
+    expr == :t && return 1
+    !(expr isa Expr && expr.head == :call) && return nothing
+    fn, args = expr.args[1], expr.args[2:end]
+    if fn == :+
+        return _get_sign_time_terms(args, fill(1, length(args)))
+    elseif fn == :- && length(args) == 1
+        sign_time = _get_sign_time(args[1])
+        return isnothing(sign_time) ? nothing : -sign_time
+    elseif fn == :- && length(args) == 2
+        return _get_sign_time_terms(args, [1, -1])
+    elseif fn == :*
+        return _get_sign_time_factors(args)
+    elseif fn == :/ && length(args) == 2
+        # With time in the denominator the direction depends on the sign of the
+        # denominator, which cannot be inferred
+        _expr_has_time(args[2]) && return nothing
+        return _get_sign_time_factors(args)
     end
-    return ""
+    return nothing
+end
+
+function _get_sign_time_terms(args, signs)::Union{Int64, Nothing}
+    sign_time = nothing
+    for (arg, sign_term) in zip(args, signs)
+        _expr_has_time(arg) == false && continue
+        _sign_time = _get_sign_time(arg)
+        isnothing(_sign_time) && return nothing
+        _sign_time *= sign_term
+        if isnothing(sign_time)
+            sign_time = _sign_time
+        elseif sign_time != _sign_time
+            # Terms with time that change in opposite directions with time
+            return nothing
+        end
+    end
+    return sign_time
+end
+
+function _get_sign_time_factors(args)::Union{Int64, Nothing}
+    itime = findall(_expr_has_time, args)
+    length(itime) != 1 && return nothing
+    sign_time = _get_sign_time(args[itime[1]])
+    isnothing(sign_time) && return nothing
+    # Direction can only be inferred if the sign of the remaining factors is known, which
+    # is the case if they are numeric values
+    for (i, arg) in pairs(args)
+        i == itime[1] && continue
+        value = _get_expr_value(arg)
+        (isnothing(value) || value == 0) && return nothing
+        sign_time *= value > 0 ? 1 : -1
+    end
+    return sign_time
+end
+
+function _get_expr_value(expr)::Union{Float64, Nothing}
+    expr isa Number && return Float64(expr)
+    if expr isa Expr && expr.head == :call && expr.args[1] == :- && length(expr.args) == 2
+        value = _get_expr_value(expr.args[2])
+        return isnothing(value) ? nothing : -value
+    end
+    return nothing
+end
+
+function _expr_has_time(expr)::Bool
+    expr == :t && return true
+    !(expr isa Expr) && return false
+    return any(_expr_has_time, expr.args)
 end
 
 function _ifelse_to_event(id::String, condition::String, side_activated)::EventSBML

--- a/src/piecewise.jl
+++ b/src/piecewise.jl
@@ -91,8 +91,10 @@ function _get_side_activated_with_time(
 end
 
 function _split_condition(formula::String)::Tuple{String, String, String}
-    gt_applys = [">", "≥", ">="]
-    lt_applys = ["<", "≤", "<="]
+    # Order matters, as, for example, >= contains >, so longer operators must be checked
+    # first for the condition to be split correctly
+    gt_applys = [">=", "≥", ">"]
+    lt_applys = ["<=", "≤", "<"]
     igt = findfirst(x -> occursin(x, formula), gt_applys)
     ilt = findfirst(x -> occursin(x, formula), lt_applys)
     @assert !all(isnothing.([igt, ilt])) "Error splitting ifelse condition"

--- a/test/Models/model_Weber_BMC2015.xml
+++ b/test/Models/model_Weber_BMC2015.xml
@@ -1,0 +1,623 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4">
+  <model id="Weber_BMC2015" name="Weber_BMC2015">
+    <notes>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <pre>PEtab implementation of the model from Weber et al. (2015), BMC Syst. Biol., 9, 9</pre>
+      </body>
+    </notes>
+    <annotation>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+        <rdf:Description rdf:about="#arFramework3">
+          <dc:creator>
+            <rdf:Bag>
+              <rdf:li rdf:parseType="Resource">
+                <vCard:N rdf:parseType="Resource">
+                  <vCard:Family>Weber</vCard:Family>
+                  <vCard:Given>Patrick</vCard:Given>
+                </vCard:N>
+              </rdf:li>
+            </rdf:Bag>
+          </dc:creator>
+          <dcterms:created rdf:parseType="Resource">
+            <dcterms:W3CDTF>2019-11-29T09:41:48Z</dcterms:W3CDTF>
+          </dcterms:created>
+          <dcterms:modified rdf:parseType="Resource">
+            <dcterms:W3CDTF>2019-11-29T09:41:48Z</dcterms:W3CDTF>
+          </dcterms:modified>
+          <bqbiol:isDescribedBy>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/doi/10.1186/s12918-015-0147-1"/>
+            </rdf:Bag>
+          </bqbiol:isDescribedBy>
+        </rdf:Description>
+      </rdf:RDF>
+    </annotation>
+    <listOfUnitDefinitions>
+      <unitDefinition id="time" name="time">
+        <listOfUnits>
+          <unit kind="second" exponent="1" scale="0" multiplier="3600"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment id="cyt" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="PKD" name="PKD" compartment="cyt" initialConcentration="466534.7994" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="PKDDAGa" name="PKD_p:DAG" compartment="cyt" initialConcentration="123.8608" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="PI4K3B" name="PI4KIII\beta" compartment="cyt" initialConcentration="1577540.5394" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="PI4K3Ba" name="PI4KIII\beta_p" compartment="cyt" initialConcentration="332054.5041" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="CERTERa" name="CERT_{a,ER}" compartment="cyt" initialConcentration="31948388.5902" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="CERT" name="CERT_{p,ER}" compartment="cyt" initialConcentration="160797.7364" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+      <species id="CERTTGNa" name="CERT_{a,TGN}" compartment="cyt" initialConcentration="42082828.6681" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="a11" value="0.183516872816456" constant="true"/>
+      <parameter id="a12" value="25.9422257786565" constant="true"/>
+      <parameter id="a21" value="1.86921330588484" constant="true"/>
+      <parameter id="a22" value="0.00010000000000001" constant="true"/>
+      <parameter id="a31" value="0.140427319109888" constant="true"/>
+      <parameter id="a32" value="0.00010000000000001" constant="true"/>
+      <parameter id="a33" value="0.00010000000000001" constant="true"/>
+      <parameter id="m11" value="9999999999.99902" constant="true"/>
+      <parameter id="m22" value="2174.18367530733" constant="true"/>
+      <parameter id="m31" value="9987839855.09162" constant="true"/>
+      <parameter id="m33" value="75601967.0948633" constant="true"/>
+      <parameter id="p11" value="4.23578569731751" constant="true"/>
+      <parameter id="p12" value="0.00601235513713934" constant="true"/>
+      <parameter id="p13" value="0.00183182922741504" constant="true"/>
+      <parameter id="p21" value="5.73048563386363" constant="true"/>
+      <parameter id="p22" value="21.3989931197985" constant="true"/>
+      <parameter id="p31" value="2428.01870197136" constant="true"/>
+      <parameter id="p32" value="17.1128427194665" constant="true"/>
+      <parameter id="p33" value="40184.0793611631" constant="true"/>
+      <parameter id="pu2" value="1" constant="true"/>
+      <parameter id="pu3" value="99999999.9999949" constant="true"/>
+      <parameter id="pu4" value="35763757.6834332" constant="true"/>
+      <parameter id="pu5" value="33.7869036338953" constant="true"/>
+      <parameter id="pu6" value="147.540504730735" constant="true"/>
+      <parameter id="s12" value="88884.6918603076" constant="true"/>
+      <parameter id="s21" value="2954405.07105195" constant="true"/>
+      <parameter id="s31" value="4345660.94708907" constant="true"/>
+      <parameter id="u2" value="0" constant="false"/>
+      <parameter id="u3" value="0" constant="false"/>
+      <parameter id="u4" value="0" constant="false"/>
+      <parameter id="u5" value="0" constant="false"/>
+      <parameter id="u6" value="0" constant="false"/>
+      <parameter id="Ect_Expr_CERT_flag" value="0" constant="false"/>
+      <parameter id="Ect_Expr_PI4K3beta_flag" value="0" constant="false"/>
+      <parameter id="PdBu_dose" value="0" constant="false"/>
+      <parameter id="PdBu_time" value="0" constant="false"/>
+      <parameter id="kb_NB142_70_dose" value="0" constant="false"/>
+      <parameter id="kb_NB142_70_time" value="0" constant="false"/>
+    </listOfParameters>
+    <listOfRules>
+      <assignmentRule variable="u2">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <cn type="integer"> 0 </cn>
+        </math>
+      </assignmentRule>
+      <assignmentRule variable="u3">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <piecewise>
+            <piece>
+              <cn type="integer"> 0 </cn>
+              <apply>
+                <lt/>
+                <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                <cn type="integer"> 0 </cn>
+              </apply>
+            </piece>
+            <otherwise>
+              <ci> Ect_Expr_PI4K3beta_flag </ci>
+            </otherwise>
+          </piecewise>
+        </math>
+      </assignmentRule>
+      <assignmentRule variable="u4">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <piecewise>
+            <piece>
+              <cn type="integer"> 0 </cn>
+              <apply>
+                <lt/>
+                <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                <cn type="integer"> 0 </cn>
+              </apply>
+            </piece>
+            <otherwise>
+              <ci> Ect_Expr_CERT_flag </ci>
+            </otherwise>
+          </piecewise>
+        </math>
+      </assignmentRule>
+      <assignmentRule variable="u5">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <piecewise>
+            <piece>
+              <cn type="integer"> 0 </cn>
+              <apply>
+                <lt/>
+                <apply>
+                  <minus/>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                  <ci> PdBu_time </ci>
+                </apply>
+                <cn type="integer"> 0 </cn>
+              </apply>
+            </piece>
+            <otherwise>
+              <ci> PdBu_dose </ci>
+            </otherwise>
+          </piecewise>
+        </math>
+      </assignmentRule>
+      <assignmentRule variable="u6">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <times/>
+            <ci> kb_NB142_70_dose </ci>
+            <piecewise>
+              <piece>
+                <cn type="integer"> 0 </cn>
+                <apply>
+                  <lt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> kb_NB142_70_time </ci>
+                  </apply>
+                  <cn type="integer"> 0 </cn>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn type="integer"> 1 </cn>
+              </otherwise>
+            </piecewise>
+          </apply>
+        </math>
+      </assignmentRule>
+    </listOfRules>
+    <listOfReactions>
+      <reaction id="v1_v_0" name="v_0" reversible="false">
+        <listOfReactants>
+          <speciesReference species="PKD" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="PKDDAGa" stoichiometry="1"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference species="CERTERa"/>
+          <modifierSpeciesReference species="PI4K3Ba"/>
+        </listOfModifiers>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> CERTERa </ci>
+                  <ci> PI4K3Ba </ci>
+                  <ci> PKD </ci>
+                  <ci> p11 </ci>
+                  <ci> p31 </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <apply>
+                    <plus/>
+                    <ci> PI4K3Ba </ci>
+                    <ci> m31 </ci>
+                  </apply>
+                  <apply>
+                    <plus/>
+                    <ci> m11 </ci>
+                    <apply>
+                      <divide/>
+                      <apply>
+                        <times/>
+                        <ci> CERTERa </ci>
+                        <ci> PI4K3Ba </ci>
+                        <ci> p31 </ci>
+                      </apply>
+                      <apply>
+                        <plus/>
+                        <ci> PI4K3Ba </ci>
+                        <ci> m31 </ci>
+                      </apply>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v2_v_1" name="v_1" reversible="false">
+        <listOfReactants>
+          <speciesReference species="PKD" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="PKDDAGa" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> PKD </ci>
+              <ci> p12 </ci>
+              <apply>
+                <plus/>
+                <apply>
+                  <times/>
+                  <ci> pu5 </ci>
+                  <ci> u5 </ci>
+                </apply>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v3_v_2" name="v_2" reversible="false">
+        <listOfReactants>
+          <speciesReference species="PKDDAGa" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="PKD" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> PKDDAGa </ci>
+              <ci> p13 </ci>
+              <apply>
+                <plus/>
+                <apply>
+                  <times/>
+                  <ci> pu6 </ci>
+                  <ci> u6 </ci>
+                </apply>
+                <cn type="integer"> 1 </cn>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v4_v_3" name="v_3" reversible="false">
+        <listOfProducts>
+          <speciesReference species="PKD" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> s12 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v5_v_4" name="v_4" reversible="false">
+        <listOfProducts>
+          <speciesReference species="PKD" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> pu2 </ci>
+              <ci> u2 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v6_v_5" name="v_5" reversible="false">
+        <listOfReactants>
+          <speciesReference species="PKD" stoichiometry="1"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> PKD </ci>
+              <ci> a11 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v7_v_6" name="v_6" reversible="false">
+        <listOfReactants>
+          <speciesReference species="PKDDAGa" stoichiometry="1"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> PKDDAGa </ci>
+              <ci> a12 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v8_v_7" name="v_7" reversible="false">
+        <listOfReactants>
+          <speciesReference species="PI4K3Ba" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="PI4K3B" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> PI4K3Ba </ci>
+              <ci> p21 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v9_v_8" name="v_8" reversible="false">
+        <listOfReactants>
+          <speciesReference species="PI4K3B" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="PI4K3Ba" stoichiometry="1"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference species="PKDDAGa"/>
+        </listOfModifiers>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> PI4K3B </ci>
+                  <ci> PKDDAGa </ci>
+                  <ci> p22 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> PKDDAGa </ci>
+                  <ci> m22 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v10_v_9" name="v_9" reversible="false">
+        <listOfProducts>
+          <speciesReference species="PI4K3B" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> s21 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v11_v_10" name="v_10" reversible="false">
+        <listOfProducts>
+          <speciesReference species="PI4K3B" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> pu3 </ci>
+              <ci> u3 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v12_v_11" name="v_11" reversible="false">
+        <listOfReactants>
+          <speciesReference species="PI4K3B" stoichiometry="1"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> PI4K3B </ci>
+              <ci> a21 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v13_v_12" name="v_12" reversible="false">
+        <listOfReactants>
+          <speciesReference species="PI4K3Ba" stoichiometry="1"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> PI4K3Ba </ci>
+              <ci> a22 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v14_v_13" name="v_13" reversible="false">
+        <listOfReactants>
+          <speciesReference species="CERTERa" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="CERTTGNa" stoichiometry="1"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference species="PI4K3Ba"/>
+        </listOfModifiers>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> CERTERa </ci>
+                  <ci> PI4K3Ba </ci>
+                  <ci> p31 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> PI4K3Ba </ci>
+                  <ci> m31 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v15_v_14" name="v_14" reversible="false">
+        <listOfReactants>
+          <speciesReference species="CERT" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="CERTERa" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> CERT </ci>
+              <ci> p32 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v16_v_15" name="v_15" reversible="false">
+        <listOfReactants>
+          <speciesReference species="CERTTGNa" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="CERT" stoichiometry="1"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference species="PKDDAGa"/>
+        </listOfModifiers>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <apply>
+                <divide/>
+                <apply>
+                  <times/>
+                  <ci> CERTTGNa </ci>
+                  <ci> PKDDAGa </ci>
+                  <ci> p33 </ci>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> PKDDAGa </ci>
+                  <ci> m33 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v17_v_16" name="v_16" reversible="false">
+        <listOfProducts>
+          <speciesReference species="CERTERa" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> s31 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v18_v_17" name="v_17" reversible="false">
+        <listOfProducts>
+          <speciesReference species="CERTERa" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> pu4 </ci>
+              <ci> u4 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v19_v_18" name="v_18" reversible="false">
+        <listOfReactants>
+          <speciesReference species="CERTERa" stoichiometry="1"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> CERTERa </ci>
+              <ci> a31 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v20_v_19" name="v_19" reversible="false">
+        <listOfReactants>
+          <speciesReference species="CERT" stoichiometry="1"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> CERT </ci>
+              <ci> a32 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="v21_v_20" name="v_20" reversible="false">
+        <listOfReactants>
+          <speciesReference species="CERTTGNa" stoichiometry="1"/>
+        </listOfReactants>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <times/>
+              <ci> cyt </ci>
+              <ci> CERTTGNa </ci>
+              <ci> a33 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/ifelse_to_callback.jl
+++ b/test/ifelse_to_callback.jl
@@ -17,3 +17,30 @@ sol2 = solve(oprob2, Rodas5P(), abstol = 1.0e-3, reltol = 1.0e-8)
 for name in unknowns(sys1)
     @test all(.≈(sol1[name], sol2[name], atol = 1.0e-9))
 end
+
+sbml_switch(cond) = """
+<sbml level="3" version="2">
+  <model id="switch">
+    <listOfParameters><parameter id="x" value="0" constant="false"/></listOfParameters>
+    <listOfRules><rateRule variable="x"><math>
+      <piecewise><piece><cn>1</cn>$cond</piece><otherwise><cn>0</cn></otherwise></piecewise>
+    </math></rateRule></listOfRules>
+  </model>
+</sbml>
+"""
+TIME = "<ci>time</ci>"
+conditions = [
+    "<apply><gt/>$TIME<cn>5</cn></apply>",                                     # t > 5
+    "<apply><lt/>$TIME<cn>5</cn></apply>",                                     # t < 5
+    "<apply><lt/><cn>5</cn>$TIME</apply>",                                     # 5 < t
+    "<apply><gt/><apply><minus/>$TIME</apply><cn>-5</cn></apply>",             # -t > -5
+    "<apply><gt/><apply><minus/>$TIME<cn>5</cn></apply><cn>0</cn></apply>",    # t - 5 > 0
+    "<apply><lt/><apply><minus/>$TIME<cn>5</cn></apply><cn>0</cn></apply>",    # t - 5 < 0
+    "<apply><gt/><apply><minus/><cn>5</cn>$TIME</apply><cn>0</cn></apply>",    # 5 - t > 0
+]
+for cond in conditions
+    rn, cb = load_SBML(sbml_switch(cond); model_as_string = true)
+    prob = ODEProblem(rn, get_u0_map(rn), (0.0, 10.0), get_parameter_map(rn))
+    sol = solve(prob, Rodas5P(); callback = cb, tstops = [5.0])
+    @test sol[rn.x][end] ≈ 5.0 atol = 1.0e-4
+end

--- a/test/ifelse_to_callback.jl
+++ b/test/ifelse_to_callback.jl
@@ -93,9 +93,11 @@ for (fn, holds) in [("gt", :after), ("geq", :after), ("lt", :before), ("leq", :b
         ("t / 2 $fn 1", _apply(fn, _apply("divide", T, _cn(2)), _cn(1)), x_time_lhs),
         ("-2t $fn -4", _apply(fn, _apply("times", _cn(-2), T), _cn(-4)), x_time_rhs),
         # Time scaled by a constant in a shifted expression
-        ("2t - 4 $fn 0",
+        (
+            "2t - 4 $fn 0",
             _apply(fn, _apply("minus", _apply("times", _cn(2), T), _cn(4)), _cn(0)),
-            x_time_lhs)
+            x_time_lhs,
+        ),
     ]
     for (name, condition, x_expected) in conditions
         @testset "Piecewise with $name in condition" begin
@@ -118,8 +120,10 @@ end
         :Ect_Expr_PI4K3beta_flag => 1.0, :Ect_Expr_CERT_flag => 1.0, :PdBu_dose => 2.0,
         :PdBu_time => 30.0, :kb_NB142_70_dose => 3.0, :kb_NB142_70_time => 60.0
     )
-    kwargs = (pset = pset, tspan = (0.0, 100.0), saveat = 0.0:5.0:100.0,
-        tstops = [30.0, 60.0])
+    kwargs = (
+        pset = pset, tspan = (0.0, 100.0), saveat = 0.0:5.0:100.0,
+        tstops = [30.0, 60.0],
+    )
     sys1, sol1 = solve_sbml(path_SBML; kwargs...)
     _, sol2 = solve_sbml(path_SBML; ifelse_to_callback = false, kwargs...)
     @test sol1.retcode == ReturnCode.Success

--- a/test/ifelse_to_callback.jl
+++ b/test/ifelse_to_callback.jl
@@ -18,29 +18,114 @@ for name in unknowns(sys1)
     @test all(.≈(sol1[name], sol2[name], atol = 1.0e-9))
 end
 
-sbml_switch(cond) = """
-<sbml level="3" version="2">
-  <model id="switch">
-    <listOfParameters><parameter id="x" value="0" constant="false"/></listOfParameters>
-    <listOfRules><rateRule variable="x"><math>
-      <piecewise><piece><cn>1</cn>$cond</piece><otherwise><cn>0</cn></otherwise></piecewise>
-    </math></rateRule></listOfRules>
-  </model>
-</sbml>
-"""
-TIME = "<ci>time</ci>"
-conditions = [
-    "<apply><gt/>$TIME<cn>5</cn></apply>",                                     # t > 5
-    "<apply><lt/>$TIME<cn>5</cn></apply>",                                     # t < 5
-    "<apply><lt/><cn>5</cn>$TIME</apply>",                                     # 5 < t
-    "<apply><gt/><apply><minus/>$TIME</apply><cn>-5</cn></apply>",             # -t > -5
-    "<apply><gt/><apply><minus/>$TIME<cn>5</cn></apply><cn>0</cn></apply>",    # t - 5 > 0
-    "<apply><lt/><apply><minus/>$TIME<cn>5</cn></apply><cn>0</cn></apply>",    # t - 5 < 0
-    "<apply><gt/><apply><minus/><cn>5</cn>$TIME</apply><cn>0</cn></apply>",    # 5 - t > 0
-]
-for cond in conditions
-    rn, cb = load_SBML(sbml_switch(cond); model_as_string = true)
-    prob = ODEProblem(rn, get_u0_map(rn), (0.0, 10.0), get_parameter_map(rn))
-    sol = solve(prob, Rodas5P(); callback = cb, tstops = [5.0])
-    @test sol[rn.x][end] ≈ 5.0 atol = 1.0e-4
+# Time can appear in many forms in a piecewise condition, and each form must be rewritten
+# to a callback that switches at the correct time, and that activates the correct piecewise
+# branch. Historically only conditions on the form t - c {>, ≥, <, ≤} 0 were correctly
+# handled, see https://github.com/sebapersson/SBMLImporter.jl/issues/168
+function solve_sbml(
+        path::String; ifelse_to_callback::Bool = true, model_as_string::Bool = false,
+        tspan = (0.0, 10.0), pset = Dict{Symbol, Float64}(), kwargs...
+    )
+    rn, cb = load_SBML(
+        path; ifelse_to_callback = ifelse_to_callback, model_as_string = model_as_string
+    )
+    sys = mtkcompile(ode_model(rn))
+    vmap = merge(Dict(get_u0_map(rn)), Dict(get_parameter_map(rn)))
+    for (id, value) in pset
+        vmap[getproperty(rn, id)] = value
+    end
+    oprob = ODEProblem(sys, vmap, tspan)
+    sol = solve(
+        oprob, Rodas5P(); callback = cb, abstol = 1.0e-10, reltol = 1.0e-10, kwargs...
+    )
+    return sys, sol
+end
+
+const TIME_MATHML = "<csymbol encoding=\"text\" definitionURL=\"http://www.sbml.org/sbml/symbols/time\"> time </csymbol>"
+_cn(value) = "<cn> $(value) </cn>"
+_apply(fn::String, args...) = "<apply><$(fn)/>" * prod(args) * "</apply>"
+
+# dx/dt = 1 if the condition holds and dx/dt = 2 otherwise. As x(0) = 0 and every
+# condition below switches value at t = 2, x is given by the analytical solutions below
+function _model_piecewise_time(condition::String)::String
+    return """<?xml version="1.0" encoding="UTF-8"?>
+    <sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2">
+      <model id="piecewise_time">
+        <listOfParameters>
+          <parameter id="x" value="0" constant="false"/>
+        </listOfParameters>
+        <listOfRules>
+          <rateRule variable="x">
+            <math xmlns="http://www.w3.org/1998/Math/MathML">
+              <piecewise>
+                <piece>$(_cn(1))$(condition)</piece>
+                <otherwise>$(_cn(2))</otherwise>
+              </piecewise>
+            </math>
+          </rateRule>
+        </listOfRules>
+      </model>
+    </sbml>
+    """
+end
+_x_holds_before(t) = t ≤ 2.0 ? t : 2.0 + 2.0 * (t - 2.0)
+_x_holds_after(t) = t ≤ 2.0 ? 2.0 * t : 4.0 + (t - 2.0)
+
+const T = TIME_MATHML
+for (fn, holds) in [("gt", :after), ("geq", :after), ("lt", :before), ("leq", :before)]
+    # holds is when the condition t fn 2 holds. If the arguments are reversed, or if the
+    # expression with time decreases with time, the opposite branch holds with time
+    x_time_lhs = holds == :after ? _x_holds_after : _x_holds_before
+    x_time_rhs = holds == :after ? _x_holds_before : _x_holds_after
+    conditions = [
+        # Time compared directly against a constant
+        ("t $fn 2", _apply(fn, T, _cn(2)), x_time_lhs),
+        ("2 $fn t", _apply(fn, _cn(2), T), x_time_rhs),
+        # Time in a shifted expression
+        ("t - 2 $fn 0", _apply(fn, _apply("minus", T, _cn(2)), _cn(0)), x_time_lhs),
+        ("0 $fn t - 2", _apply(fn, _cn(0), _apply("minus", T, _cn(2))), x_time_rhs),
+        ("2 - t $fn 0", _apply(fn, _apply("minus", _cn(2), T), _cn(0)), x_time_rhs),
+        ("0 $fn 2 - t", _apply(fn, _cn(0), _apply("minus", _cn(2), T)), x_time_lhs),
+        # Negated time
+        ("-t $fn -2", _apply(fn, _apply("minus", T), _cn(-2)), x_time_rhs),
+        # Time scaled by a constant
+        ("2t $fn 4", _apply(fn, _apply("times", _cn(2), T), _cn(4)), x_time_lhs),
+        ("t / 2 $fn 1", _apply(fn, _apply("divide", T, _cn(2)), _cn(1)), x_time_lhs),
+        ("-2t $fn -4", _apply(fn, _apply("times", _cn(-2), T), _cn(-4)), x_time_rhs),
+        # Time scaled by a constant in a shifted expression
+        ("2t - 4 $fn 0",
+            _apply(fn, _apply("minus", _apply("times", _cn(2), T), _cn(4)), _cn(0)),
+            x_time_lhs)
+    ]
+    for (name, condition, x_expected) in conditions
+        @testset "Piecewise with $name in condition" begin
+            _, sol = solve_sbml(
+                _model_piecewise_time(condition); model_as_string = true,
+                saveat = 0.0:0.5:10.0
+            )
+            @test all(.≈(sol[:x], x_expected.(sol.t), atol = 1.0e-6))
+        end
+    end
+end
+
+# The Weber model has piecewise expressions where time is compared directly against a
+# constant (t < 0), and where time appears in a shifted expression (t - PdBu_time < 0)
+@testset "Piecewise with time in condition Weber model" begin
+    path_SBML = joinpath(@__DIR__, "Models", "model_Weber_BMC2015.xml")
+    # Default parameter values switch off every piecewise branch, hence values that
+    # trigger the piecewise expressions within the time-span are used
+    pset = Dict(
+        :Ect_Expr_PI4K3beta_flag => 1.0, :Ect_Expr_CERT_flag => 1.0, :PdBu_dose => 2.0,
+        :PdBu_time => 30.0, :kb_NB142_70_dose => 3.0, :kb_NB142_70_time => 60.0
+    )
+    kwargs = (pset = pset, tspan = (0.0, 100.0), saveat = 0.0:5.0:100.0,
+        tstops = [30.0, 60.0])
+    sys1, sol1 = solve_sbml(path_SBML; kwargs...)
+    _, sol2 = solve_sbml(path_SBML; ifelse_to_callback = false, kwargs...)
+    @test sol1.retcode == ReturnCode.Success
+    # u3-u6 are the piecewise assignment rule variables, and they all appear in reaction
+    # kinetic laws, hence any error in the rewritten piecewise propagates to the species
+    for name in unknowns(sys1)
+        @test all(.≈(sol1[name], sol2[name], rtol = 1.0e-6, atol = 1.0e-8))
+    end
 end


### PR DESCRIPTION
Fixes #168 
Previous code was not consistent on left and right definitions, so it could be that if a flag turned on at the start, it would stay on and could not change. Fix: swap left and right

Previous code flipped sign of t when stripping parenthesis with -, e.g., `t-5 > 0` becomes `-(t, 5.0)` became `-t` when removing `(`, so `t-c > 0` worked (canceling out the inconsistent left and right definitions) and `t > c` did not. Fix: recognize `-(`

this is prob how the left and right confusion originated